### PR TITLE
Feat: unlock legacy withdrawal cells

### DIFF
--- a/apps/godwoken-bridge/src/components/Deposit/DepositItem.tsx
+++ b/apps/godwoken-bridge/src/components/Deposit/DepositItem.tsx
@@ -45,11 +45,15 @@ const StyleWrapper = styled.div`
       height: 22px;
       margin-right: 5px;
     }
+    .ckb-icon {
+      display: flex;
+      align-items: center;
+    }
     .ckb-amount {
       display: flex;
     }
     .sudt-amount + .ckb-amount {
-      margin-top: 10px;
+      margin-top: 6px;
     }
     &:hover {
       cursor: pointer;
@@ -70,6 +74,7 @@ const StyleWrapper = styled.div`
     }
   }
   .list-detail {
+    margin-top: 10px;
     padding-top: 10px;
     width: 100%;
     border-top: 1px dashed rgba(0, 0, 0, 0.2);

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV0.tsx
@@ -5,7 +5,6 @@ import QuestionCircleOutlined from "@ant-design/icons/lib/icons/QuestionCircleOu
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { LightGodwokenV0 } from "light-godwoken";
 import { useInfiniteScroll } from "ahooks";
-import { useQuery } from "react-query";
 import { providers } from "ethers";
 import { LinkList, Tab } from "../../style/common";
 import { useClock } from "../../hooks/useClock";
@@ -136,7 +135,7 @@ export const WithdrawalList: React.FC = () => {
         <div className="list pending-list">
           {pendingList.length === 0 && "There is no pending withdrawal request here"}
           {pendingList.map((withdraw, index) => (
-            <WithdrawalRequestCard now={now} {...withdraw} key={index}></WithdrawalRequestCard>
+            <WithdrawalRequestCard now={now} {...withdraw} key={index} />
           ))}
         </div>
       )}
@@ -144,7 +143,7 @@ export const WithdrawalList: React.FC = () => {
         <div className="list pending-list">
           {completedList.length === 0 && "There is no completed withdrawal request here"}
           {completedList.map((withdraw: any, index: number) => (
-            <WithdrawalRequestCard now={now} {...withdraw} key={index}></WithdrawalRequestCard>
+            <WithdrawalRequestCard now={now} {...withdraw} key={index} />
           ))}
         </div>
       )}

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV0.tsx
@@ -114,19 +114,8 @@ export const WithdrawalList: React.FC = () => {
 
   const godwokenVersion = useGodwokenVersion();
   const l1Address = useMemo(() => lightGodwoken?.provider.getL1Address(), [lightGodwoken]);
-  const { unlockHistory, addUnlockHistoryItem, setUnlockHistory } = useL1UnlockHistory(
-    `${godwokenVersion}/${l1Address}/unlock`,
-  );
+  const { unlockHistory, setUnlockHistory } = useL1UnlockHistory(`${godwokenVersion}/${l1Address}/unlock`);
   useEffect(() => {
-    // TODO: delete after testing
-    /*const pendingTestTarget = pendingList.find((row) => row.layer1TxHash === "0x9434a536abf55ff5f275eea637cad6eb560df61cff53a0bc2bd376e1b9266e61");
-    if (pendingTestTarget) {
-      addUnlockHistoryItem({
-        withdrawalTxHash: pendingTestTarget.layer1TxHash,
-        unlockTxHash: pendingTestTarget.layer1TxHash,
-      });
-    }*/
-
     const removed = unlockHistory.filter((row) => !completedLayer1TxHashList.includes(row.withdrawalTxHash));
     if (removed.length < unlockHistory.length) {
       setUnlockHistory(removed);

--- a/apps/godwoken-bridge/src/components/Withdrawal/TokenInfoWithAmount.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/TokenInfoWithAmount.tsx
@@ -14,7 +14,7 @@ export const TokenInfoWithAmount: TokenInfoWithAmountType = (props: TokenInfoWit
   }
 
   return (
-    <div style={{ marginTop: 10 }}>
+    <div className="sudt-amount">
       {props.tokenURI ? (
         <img src={props.tokenURI} alt="" />
       ) : (

--- a/apps/godwoken-bridge/src/components/Withdrawal/Unlock.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/Unlock.tsx
@@ -183,15 +183,16 @@ const Unlock: React.FC<UnlockProps> = ({ layer1TxHash, erc20, cell }) => {
             </LoadingWrapper>
           )}
           {isUnlocking && <Tips>Waiting for User Confirmation</Tips>}
-
-          <Actions>
-            <PlainButton className="cancel" onClick={handleCancel}>
-              Cancel
-            </PlainButton>
-            <SecondeButton className="confirm" onClick={unlock} disabled={isUnlocking}>
-              Confirm
-            </SecondeButton>
-          </Actions>
+          {!isUnlocking && (
+            <Actions>
+              <PlainButton className="cancel" onClick={handleCancel}>
+                Cancel
+              </PlainButton>
+              <SecondeButton className="confirm" onClick={unlock} disabled={isUnlocking}>
+                Confirm
+              </SecondeButton>
+            </Actions>
+          )}
         </ModalContent>
       </ConfirmModal>
     </div>

--- a/apps/godwoken-bridge/src/components/Withdrawal/Unlock.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/Unlock.tsx
@@ -1,0 +1,205 @@
+import React, { useMemo, useState } from "react";
+import styled from "styled-components";
+import { notification } from "antd";
+import { utils as ethersUtils } from "ethers";
+import { BI, Cell, utils } from "@ckb-lumos/lumos";
+import { captureException } from "@sentry/react";
+import { LoadingOutlined } from "@ant-design/icons";
+import { NotEnoughCapacityError, ProxyERC20, SUDT } from "light-godwoken";
+import {
+  Actions,
+  ConfirmModal,
+  LoadingWrapper,
+  MainText,
+  PlainButton,
+  SecondeButton,
+  Text,
+  Tips,
+} from "../../style/common";
+import { ReactComponent as CKBIcon } from "../../assets/ckb.svg";
+import { isInstanceOfLightGodwokenV0 } from "../../utils/typeAssert";
+import { useGodwokenVersion } from "../../hooks/useGodwokenVersion";
+import { useLightGodwoken } from "../../hooks/useLightGodwoken";
+import { useL1TxHistory } from "../../hooks/useL1TxHistory";
+import { TokenInfoWithAmount } from "./TokenInfoWithAmount";
+import { getDisplayAmount } from "../../utils/formatTokenAmount";
+
+const ModalContent = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .amount {
+    padding: 6px 12px 8px 12px;
+    margin-bottom: 12px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    border-radius: 16px;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+
+    img,
+    svg {
+      width: 22px;
+      height: 22px;
+      margin-right: 5px;
+    }
+    .ckb-amount {
+      display: flex;
+    }
+    .sudt-amount + .ckb-amount {
+      margin-top: 10px;
+    }
+  }
+  .title {
+    font-size: 14px;
+    font-weight: bold;
+  }
+`;
+
+export interface UnlockProps {
+  erc20?: ProxyERC20;
+  cell: Cell;
+}
+
+const Unlock: React.FC<UnlockProps> = ({ erc20, cell }) => {
+  // light-godwoken client
+  const lightGodwoken = useLightGodwoken();
+  const l1Address = useMemo(() => lightGodwoken?.provider.getL1Address(), [lightGodwoken]);
+  const tokenMap = useMemo(() => lightGodwoken?.getBuiltinSUDTMapByTypeHash() || {}, [lightGodwoken]);
+
+  // state
+  const [isUnlocking, setIsUnlocking] = useState(false);
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  // tx history
+  const godwokenVersion = useGodwokenVersion();
+  const { addTxToHistory } = useL1TxHistory(`${godwokenVersion}/${l1Address}/withdrawal`);
+
+  // ckb capacity
+  const ckbCapacity = useMemo(() => {
+    console.log(cell.cell_output.capacity);
+    const capacity = ethersUtils.parseUnits(BI.from(cell.cell_output.capacity).toString(), 8).toHexString();
+    return getDisplayAmount(BI.from(capacity), 8);
+  }, [cell.cell_output.capacity]);
+
+  // sudt
+  let token: SUDT | undefined;
+  let amount: string | undefined;
+  if (cell.cell_output.type) {
+    token = tokenMap[utils.computeScriptHash(cell.cell_output.type)];
+    amount = utils.readBigUInt128LECompatible(cell.data).toHexString();
+  }
+
+  if (lightGodwoken?.getVersion().toString() !== "v0") {
+    return <></>;
+  }
+
+  async function unlock() {
+    if (!isInstanceOfLightGodwokenV0(lightGodwoken)) {
+      return;
+    }
+
+    setIsUnlocking(true);
+    try {
+      const txHash = await lightGodwoken.unlock({ cell });
+      addTxToHistory({
+        type: "withdrawal",
+        txHash,
+        capacity: cell.cell_output.capacity,
+        amount: amount || "0x0",
+        token: token,
+        status: "succeed",
+      });
+
+      notification.success({
+        message: `Unlock Tx(${txHash}) success`,
+        onClick: () => linkToExplorer(txHash),
+      });
+    } catch (e) {
+      handleError(e);
+    } finally {
+      setIsUnlocking(false);
+      setIsModalVisible(false);
+    }
+  }
+
+  function linkToExplorer(txHash: string) {
+    if (!lightGodwoken) return;
+    const config = lightGodwoken.getConfig();
+    window.open(`${config.layer1Config.SCANNER_URL}/transaction/${txHash}`, "_blank");
+  }
+  function handleError(e: unknown) {
+    (() => {
+      console.error(e);
+      if (e instanceof NotEnoughCapacityError) {
+        notification.error({ message: `Unlock Transaction fail, you need to get some ckb on L1 first` });
+        return;
+      }
+      if (e instanceof Error) {
+        notification.error({ message: `Unknown error, please try again later` });
+      }
+    })();
+
+    captureException(e);
+  }
+
+  function showCurrencySelectModal() {
+    setIsModalVisible(true);
+  }
+  function handleOk() {
+    setIsModalVisible(false);
+  }
+  function handleCancel() {
+    setIsModalVisible(false);
+  }
+
+  return (
+    <div onClick={(e) => e.stopPropagation()}>
+      <SecondeButton className="withdraw-button" onClick={showCurrencySelectModal}>
+        Unlock
+      </SecondeButton>
+      <ConfirmModal
+        title="Unlock Withdrawal"
+        visible={isModalVisible}
+        onOk={handleOk}
+        onCancel={handleCancel}
+        footer={null}
+        width={400}
+      >
+        <ModalContent>
+          <div className="amount">
+            {erc20 && <TokenInfoWithAmount amount={BI.from(amount || "0x0")} {...erc20} />}
+            <div className="ckb-amount">
+              <div className="ckb-icon">
+                <CKBIcon />
+              </div>
+              <MainText>{ckbCapacity}</MainText>
+            </div>
+          </div>
+
+          <Text className="title">Unlock target address</Text>
+          <Text>{l1Address}</Text>
+
+          {isUnlocking && (
+            <LoadingWrapper>
+              <LoadingOutlined />
+            </LoadingWrapper>
+          )}
+          {isUnlocking && <Tips>Waiting for User Confirmation</Tips>}
+
+          <Actions>
+            <PlainButton className="cancel" onClick={handleCancel}>
+              Cancel
+            </PlainButton>
+            <SecondeButton className="confirm" onClick={unlock} disabled={isUnlocking}>
+              Confirm
+            </SecondeButton>
+          </Actions>
+        </ModalContent>
+      </ConfirmModal>
+    </div>
+  );
+};
+
+export default Unlock;

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react";
 import styled from "styled-components";
 import { Tooltip } from "antd";
-import { CheckCircleOutlined, CloseCircleOutlined, FieldTimeOutlined } from "@ant-design/icons";
+import { CheckCircleOutlined, CloseCircleOutlined, FieldTimeOutlined, LoadingOutlined } from "@ant-design/icons";
 import { BI, Cell, HexNumber, HexString } from "@ckb-lumos/lumos";
 import { ProxyERC20 } from "light-godwoken";
 import getTimePeriods from "../../utils/getTimePeriods";
@@ -14,6 +14,8 @@ import { MainText } from "../../style/common";
 import { COLOR } from "../../style/variables";
 import { TokenInfoWithAmount } from "./TokenInfoWithAmount";
 import Unlock from "./Unlock";
+import { useGodwokenVersion } from "../../hooks/useGodwokenVersion";
+import { useL1UnlockHistory } from "../../hooks/useL1UnlockHistory";
 
 const StyleWrapper = styled.div`
   background: #f3f3f3;
@@ -40,11 +42,15 @@ const StyleWrapper = styled.div`
       height: 22px;
       margin-right: 5px;
     }
+    .ckb-icon {
+      display: flex;
+      align-items: center;
+    }
     .ckb-amount {
       display: flex;
     }
     .sudt-amount + .ckb-amount {
-      margin-top: 10px;
+      margin-top: 6px;
     }
   }
   .right-side {
@@ -62,6 +68,7 @@ const StyleWrapper = styled.div`
     }
   }
   .list-detail {
+    margin-top: 10px;
     padding-top: 10px;
     border-top: 1px dashed rgba(0, 0, 0, 0.2);
     a {
@@ -105,18 +112,27 @@ const WithdrawalRequestCard = ({
   layer1TxHash,
   isFastWithdrawal,
 }: IWithdrawalRequestCardProps) => {
+  // state
   const [shouldShowMore, setShouldShowMore] = useState(false);
-  const [blockProduceTime, setBlockProduceTime] = useState(0);
-  const lightGodwoken = useLightGodwoken();
-  const l1ScannerUrl = lightGodwoken?.getConfig().layer1Config.SCANNER_URL;
 
+  // light-godwoken
+  const lightGodwoken = useLightGodwoken();
+  const l1Address = useMemo(() => lightGodwoken?.provider.getL1Address(), [lightGodwoken]);
+  const l1ScannerUrl = useMemo(() => lightGodwoken?.getConfig().layer1Config.SCANNER_URL, [lightGodwoken]);
+
+  // block produce time
+  const [blockProduceTime, setBlockProduceTime] = useState(0);
   useEffect(() => {
-    const fetchBlockProduceTime = async () => {
+    async function fetchBlockProduceTime() {
       const result: number = (await lightGodwoken?.getBlockProduceTime()) || 0;
       setBlockProduceTime(result);
-    };
+    }
     fetchBlockProduceTime();
   }, [lightGodwoken]);
+
+  // unlock history
+  const godwokenVersion = useGodwokenVersion();
+  const { unlockHistory } = useL1UnlockHistory(`${godwokenVersion}/${l1Address}/unlock`);
 
   const estimatedArrivalDate = useMemo(
     () => Date.now() + remainingBlockNumber * blockProduceTime,
@@ -124,6 +140,23 @@ const WithdrawalRequestCard = ({
   );
   const estimatedSecondsLeft = useMemo(() => Math.max(0, estimatedArrivalDate - now), [now, estimatedArrivalDate]);
   const isMature = useMemo(() => remainingBlockNumber === 0, [remainingBlockNumber]);
+  const hasOutpoint = useMemo(() => cell?.out_point !== void 0, [cell]);
+  const matchedUnlockHistory = useMemo(() => {
+    return layer1TxHash ? unlockHistory.find((row) => row.withdrawalTxHash === layer1TxHash) : void 0;
+  }, [unlockHistory, layer1TxHash]);
+
+  const [isLiveCell, setIsLiveCell] = useState<boolean | undefined>();
+  useEffect(() => {
+    async function updateIsLiveCell() {
+      if (status === "available" && hasOutpoint) {
+        const liveCell = await lightGodwoken!.provider.ckbRpc.get_live_cell(cell!.out_point!, false);
+        setIsLiveCell(liveCell.status === "live");
+      } else {
+        setIsLiveCell(false);
+      }
+    }
+    updateIsLiveCell();
+  }, [lightGodwoken, hasOutpoint, status, cell]);
 
   const {
     days: daysLeft,
@@ -179,13 +212,31 @@ const WithdrawalRequestCard = ({
           )}
           {status === "pending" && !shouldShowMore && (
             <div className="time">
-              <MainText title="Estimated time left">{isDue ? "Unlocking, please wait..." : countdownText}</MainText>
-              {isDue ? null : <ArrowDownIcon />}
+              {isDue && (
+                <Tooltip title="Unlocking withdrawal">
+                  <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
+                </Tooltip>
+              )}
+              {!isDue && (
+                <>
+                  <MainText title="Estimated time left">{countdownText}</MainText>
+                  <ArrowDownIcon />
+                </>
+              )}
             </div>
           )}
-          {status === "available" && cell && <Unlock cell={cell} erc20={erc20} />}
+          {status === "available" && hasOutpoint && !matchedUnlockHistory && isLiveCell === true && (
+            <Tooltip title="Unlock withdrawal to your address">
+              <Unlock cell={cell!} layer1TxHash={layer1TxHash!} erc20={erc20} />
+            </Tooltip>
+          )}
+          {status === "available" && hasOutpoint && (matchedUnlockHistory || isLiveCell === false) && (
+            <Tooltip title="Unlocking withdrawal">
+              <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
+            </Tooltip>
+          )}
           {status === "succeed" && (
-            <Tooltip title={status}>
+            <Tooltip title="Withdrawal succeed">
               <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />
             </Tooltip>
           )}

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
@@ -146,14 +146,17 @@ const WithdrawalRequestCard = ({
   }, [unlockHistory, layer1TxHash]);
 
   const [isLiveCell, setIsLiveCell] = useState<boolean | undefined>();
+  const [isLoadingLiveCell, setIsLoadingLiveCell] = useState(false);
   useEffect(() => {
     async function updateIsLiveCell() {
       if (status === "available" && hasOutpoint) {
+        setIsLoadingLiveCell(true);
         const liveCell = await lightGodwoken!.provider.ckbRpc.get_live_cell(cell!.out_point!, false);
         setIsLiveCell(liveCell.status === "live");
       } else {
         setIsLiveCell(false);
       }
+      setIsLoadingLiveCell(false);
     }
     updateIsLiveCell();
   }, [lightGodwoken, hasOutpoint, status, cell]);
@@ -230,11 +233,13 @@ const WithdrawalRequestCard = ({
               <Unlock cell={cell!} layer1TxHash={layer1TxHash!} erc20={erc20} />
             </Tooltip>
           )}
-          {status === "available" && hasOutpoint && (matchedUnlockHistory || isLiveCell === false) && (
-            <Tooltip title="Unlocking withdrawal">
-              <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
-            </Tooltip>
-          )}
+          {status === "available" &&
+            hasOutpoint &&
+            (isLoadingLiveCell || matchedUnlockHistory || isLiveCell === false) && (
+              <Tooltip title="Unlocking withdrawal">
+                <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
+              </Tooltip>
+            )}
           {status === "succeed" && (
             <Tooltip title="Withdrawal succeed">
               <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
@@ -1,18 +1,19 @@
 import React, { useState, useCallback, useEffect, useMemo } from "react";
 import styled from "styled-components";
-import getTimePeriods from "../../utils/getTimePeriods";
-import { getDisplayAmount } from "../../utils/formatTokenAmount";
+import { Tooltip } from "antd";
+import { CheckCircleOutlined, CloseCircleOutlined, FieldTimeOutlined } from "@ant-design/icons";
 import { BI, Cell, HexNumber, HexString } from "@ckb-lumos/lumos";
 import { ProxyERC20 } from "light-godwoken";
+import getTimePeriods from "../../utils/getTimePeriods";
+import { getDisplayAmount } from "../../utils/formatTokenAmount";
 import { useLightGodwoken } from "../../hooks/useLightGodwoken";
 import { ReactComponent as CKBIcon } from "../../assets/ckb.svg";
 import { ReactComponent as ArrowDownIcon } from "../../assets/arrow-down.svg";
 import { ReactComponent as ArrowUpIcon } from "../../assets/arrow-up.svg";
 import { MainText } from "../../style/common";
 import { COLOR } from "../../style/variables";
-import { CheckCircleOutlined, CloseCircleOutlined, FieldTimeOutlined } from "@ant-design/icons";
-import { Tooltip } from "antd";
 import { TokenInfoWithAmount } from "./TokenInfoWithAmount";
+import Unlock from "./Unlock";
 
 const StyleWrapper = styled.div`
   background: #f3f3f3;
@@ -86,12 +87,12 @@ export interface IWithdrawalRequestCardProps {
   remainingBlockNumber?: number;
   capacity: HexNumber;
   amount: HexNumber;
-  status: string;
   cell?: Cell;
   erc20?: ProxyERC20;
   now?: number;
   layer1TxHash?: HexString;
   isFastWithdrawal: boolean;
+  status: "pending" | "available" | "succeed" | "failed";
 }
 const WithdrawalRequestCard = ({
   remainingBlockNumber = 0,
@@ -99,6 +100,7 @@ const WithdrawalRequestCard = ({
   amount,
   status,
   erc20,
+  cell,
   now = 0,
   layer1TxHash,
   isFastWithdrawal,
@@ -157,7 +159,7 @@ const WithdrawalRequestCard = ({
           {erc20 && <TokenInfoWithAmount amount={amount} {...erc20} />}
           <div className="ckb-amount">
             <div className="ckb-icon">
-              <CKBIcon></CKBIcon>
+              <CKBIcon />
             </div>
             <MainText>{CKBAmount}</MainText>
             {isFastWithdrawal && (
@@ -170,23 +172,22 @@ const WithdrawalRequestCard = ({
           </div>
         </div>
         <div className="right-side">
-          {status === "pending" &&
-            (shouldShowMore ? (
-              <div className="time">
-                <ArrowUpIcon />
-              </div>
-            ) : (
-              <div className="time">
-                <MainText title="Estimated time left">{isDue ? "Unlocking, please wait..." : countdownText}</MainText>
-                {isDue ? null : <ArrowDownIcon />}
-              </div>
-            ))}
-          {status === "success" && (
-            <>
-              <Tooltip title={status}>
-                <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />
-              </Tooltip>
-            </>
+          {status === "pending" && shouldShowMore && (
+            <div className="time">
+              <ArrowUpIcon />
+            </div>
+          )}
+          {status === "pending" && !shouldShowMore && (
+            <div className="time">
+              <MainText title="Estimated time left">{isDue ? "Unlocking, please wait..." : countdownText}</MainText>
+              {isDue ? null : <ArrowDownIcon />}
+            </div>
+          )}
+          {status === "available" && cell && <Unlock cell={cell} erc20={erc20} />}
+          {status === "succeed" && (
+            <Tooltip title={status}>
+              <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />
+            </Tooltip>
           )}
           {status === "failed" && (
             <Tooltip title="Withdrawal failed">
@@ -195,7 +196,7 @@ const WithdrawalRequestCard = ({
           )}
         </div>
       </div>
-      {status === "success" && (
+      {status === "succeed" && (
         <div className="list-detail">
           <FixedHeightRow>
             <MainText title={layer1TxHash}>

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -177,7 +177,7 @@ const WithdrawalRequestCard = ({
                 <ArrowDownIcon />
               </div>
             ))}
-          {status === "success" && (
+          {status === "succeed" && (
             <Tooltip title={status}>
               <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />
             </Tooltip>
@@ -196,7 +196,7 @@ const WithdrawalRequestCard = ({
           )}
         </div>
       </div>
-      {status === "success" && (
+      {status === "succeed" && (
         <div className="list-detail">
           <FixedHeightRow>
             <MainText title={layer1TxHash}>

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -49,7 +49,7 @@ const StyleWrapper = styled.div`
       align-items: center;
     }
     .sudt-amount + .ckb-amount {
-      margin-top: 10px;
+      margin-top: 6px;
     }
   }
   .right-side {
@@ -68,6 +68,7 @@ const StyleWrapper = styled.div`
     }
   }
   .list-detail {
+    margin-top: 10px;
     padding-top: 10px;
     border-top: 1px dashed rgba(0, 0, 0, 0.2);
     a {

--- a/apps/godwoken-bridge/src/hooks/useL1UnlockHistory.ts
+++ b/apps/godwoken-bridge/src/hooks/useL1UnlockHistory.ts
@@ -1,0 +1,51 @@
+import { Hash } from "@ckb-lumos/lumos";
+import { useCallback, useMemo } from "react";
+import { useLocalStorage } from "@rehooks/local-storage";
+
+export interface ManualUnlockHistory {
+  withdrawalTxHash: Hash;
+  unlockTxHash: Hash;
+}
+
+export function useL1UnlockHistory(storageKey: string) {
+  const [unlockHistory, setUnlockHistory] = useLocalStorage<ManualUnlockHistory[]>(storageKey, []);
+
+  const updateUnlockHistoryItem = useCallback(
+    (history: ManualUnlockHistory) => {
+      const mapped = unlockHistory.map((row) => (row.withdrawalTxHash === history.withdrawalTxHash ? history : row));
+      setUnlockHistory(mapped);
+    },
+    [unlockHistory, setUnlockHistory],
+  );
+
+  const addUnlockHistoryItem = useCallback(
+    (history: ManualUnlockHistory) => {
+      const exists = unlockHistory.find((row) => row.withdrawalTxHash === history.withdrawalTxHash);
+      if (!exists) {
+        const copiedList = [...unlockHistory];
+        copiedList.push(history);
+        setUnlockHistory(copiedList);
+      }
+    },
+    [unlockHistory, setUnlockHistory],
+  );
+
+  const removeUnlockHistoryItem = useCallback(
+    (withdrawalTxHash: Hash) => {
+      const filtered = unlockHistory.filter((row) => row.withdrawalTxHash !== withdrawalTxHash);
+      setUnlockHistory(filtered);
+    },
+    [unlockHistory, setUnlockHistory],
+  );
+
+  return useMemo(
+    () => ({
+      unlockHistory,
+      setUnlockHistory,
+      addUnlockHistoryItem,
+      updateUnlockHistoryItem,
+      removeUnlockHistoryItem,
+    }),
+    [unlockHistory, setUnlockHistory, addUnlockHistoryItem, updateUnlockHistoryItem, removeUnlockHistoryItem],
+  );
+}

--- a/apps/godwoken-bridge/src/hooks/useL1UnlockHistory.ts
+++ b/apps/godwoken-bridge/src/hooks/useL1UnlockHistory.ts
@@ -1,5 +1,5 @@
 import { Hash } from "@ckb-lumos/lumos";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useLocalStorage } from "@rehooks/local-storage";
 
 export interface ManualUnlockHistory {
@@ -9,6 +9,16 @@ export interface ManualUnlockHistory {
 
 export function useL1UnlockHistory(storageKey: string) {
   const [unlockHistory, setUnlockHistory] = useLocalStorage<ManualUnlockHistory[]>(storageKey, []);
+
+  useEffect(() => {
+    try {
+      const list = JSON.parse(localStorage.getItem(storageKey) || "[]");
+      setUnlockHistory(list);
+    } catch {
+      console.warn("no storage was found for storageKey:", storageKey);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey]);
 
   const updateUnlockHistoryItem = useCallback(
     (history: ManualUnlockHistory) => {

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,8 @@
   "version": "0.2.0",
   "packages": [
     "packages/**",
-    "apps/**"
+    "apps/**",
+    "scripts"
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/packages/light-godwoken/src/LightGodwokenV0.ts
+++ b/packages/light-godwoken/src/LightGodwokenV0.ts
@@ -602,11 +602,13 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
       dep_type: withdrawalLockCellDep.dep_type,
     };
 
-    const newWitnessArgs: WitnessArgs = {
-      lock: "0x0000000004000000",
-    };
+    // https://github.com/classicalliu/gw-demos/blob/main/src/unlock.ts#L48
     const withdrawalWitness = new toolkit.Reader(
-      core.SerializeWitnessArgs(toolkit.normalizers.NormalizeWitnessArgs(newWitnessArgs)),
+      core.SerializeWitnessArgs(
+        toolkit.normalizers.NormalizeWitnessArgs({
+          lock: "0x0000000004000000",
+        }),
+      ),
     ).serializeJson();
 
     txSkeleton = txSkeleton

--- a/packages/light-godwoken/src/LightGodwokenV1.ts
+++ b/packages/light-godwoken/src/LightGodwokenV1.ts
@@ -258,10 +258,10 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
         withdrawalBlockNumber: item.block_number,
         remainingBlockNumber: Math.max(0, item.block_number - lastFinalizedBlockNumber),
         capacity: BI.from(item.capacity).toHexString(),
-        amount,
         sudt_script_hash: item.udt_script_hash,
+        amount,
         erc20,
-        status: item.state === "succeed" ? "success" : item.state,
+        status: item.state,
       };
     });
   }

--- a/packages/light-godwoken/src/__tests__/utils.ts
+++ b/packages/light-godwoken/src/__tests__/utils.ts
@@ -1,6 +1,6 @@
 import { Cell, HexString, Script, HashType, BI, helpers, utils } from "@ckb-lumos/lumos";
 import { LightGodwokenConfig } from "../config";
-import { RawWithdrwal } from "../schemas/codecV0";
+import { RawWithdrawal } from "../schemas/codecV0";
 import { RawWithdrawalRequestV1 } from "../schemas/codecV1";
 
 export const randomHexString = (byteLength: number) => {
@@ -82,16 +82,16 @@ export const outputSudtAmountOf = (tx: helpers.TransactionSkeletonType): BI => {
     .div(1000000000000000000);
 };
 
-export const deBifyRawWithdrawalRequestV0 = (rawWithdrwal: RawWithdrwal) => {
+export const deBifyRawWithdrawalRequestV0 = (rawWithdrawal: RawWithdrawal) => {
   return {
-    ...rawWithdrwal,
-    capacity: rawWithdrwal.capacity.toHexString(),
-    amount: rawWithdrwal.amount.toHexString(),
-    sell_amount: rawWithdrwal.sell_amount.toHexString(),
-    sell_capacity: rawWithdrwal.sell_capacity.toHexString(),
+    ...rawWithdrawal,
+    capacity: rawWithdrawal.capacity.toHexString(),
+    amount: rawWithdrawal.amount.toHexString(),
+    sell_amount: rawWithdrawal.sell_amount.toHexString(),
+    sell_capacity: rawWithdrawal.sell_capacity.toHexString(),
     fee: {
-      amount: rawWithdrwal.fee.amount.toHexString(),
-      sudt_id: rawWithdrwal.fee.sudt_id,
+      amount: rawWithdrawal.fee.amount.toHexString(),
+      sudt_id: rawWithdrawal.fee.sudt_id,
     },
   };
 };

--- a/packages/light-godwoken/src/config/predefined/mainnet.ts
+++ b/packages/light-godwoken/src/config/predefined/mainnet.ts
@@ -51,7 +51,7 @@ export const MainnetLayer2ConfigV0: LightGodwokenConfig = {
         script_type_hash: "0xf1717ee388b181fcb14352055c00b7ea7cd7c27350ffd1a2dd231e059dde2fed",
         cell_dep: {
           out_point: {
-            tx_hash: "0x3d727bd8bb1d87ba79638b63bfbf4c9a4feb9ac5ac5a0b356f3aaf4ccb4d3a1c",
+            tx_hash: "0x342dc7b96e663393fa606f05ae1ad8504fa776436d552677356b1023bb174beb",
             index: "0x0",
           },
           dep_type: "code",

--- a/packages/light-godwoken/src/godwokenScanner/requestTypes/withdrawalHistories.ts
+++ b/packages/light-godwoken/src/godwokenScanner/requestTypes/withdrawalHistories.ts
@@ -12,7 +12,7 @@ export interface WithdrawalHistory {
   layer1_output_index: number;
   layer1_tx_hash: Hash;
   owner_lock_hash: Hash;
-  state: "pending" | "succeed" | "failed";
+  state: "pending" | "available" | "succeed" | "failed";
   timestamp: string;
   udt_id: number;
   udt_script_hash: Hash;

--- a/packages/light-godwoken/src/lightGodwoken.ts
+++ b/packages/light-godwoken/src/lightGodwoken.ts
@@ -40,7 +40,6 @@ import {
   TransactionSignError,
   WithdrawalTimeoutError,
 } from "./constants/error";
-import { getTokenList } from "./tokens";
 
 export default abstract class DefaultLightGodwoken implements LightGodwokenBase {
   provider: LightGodwokenProvider;
@@ -885,9 +884,9 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
    *
    * @param tx
    * @param fromScript
-   * @param capacity
+   * @param neededCapacity
    *
-   * collect some pure cells and apend them to both input and output sides of the tx.
+   * collect some pure cells and append them to both input and output sides of the tx.
    * later we can pay tx fee from output side.
    */
   async appendPureCkbCell(
@@ -909,8 +908,7 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
     }
     if (collectedSum.lt(neededCapacity)) {
       const message = `Not enough CKB, expected: ${neededCapacity}, actual: ${collectedSum} `;
-      const error = new NotEnoughCapacityError({ expected: neededCapacity, actual: collectedSum }, message);
-      throw error;
+      throw new NotEnoughCapacityError({ expected: neededCapacity, actual: collectedSum }, message);
     }
     const changeOutput: Cell = {
       cell_output: {

--- a/packages/light-godwoken/src/lightGodwokenProvider.ts
+++ b/packages/light-godwoken/src/lightGodwokenProvider.ts
@@ -242,9 +242,7 @@ export default class DefaultLightGodwokenProvider implements LightGodwokenProvid
   }
 
   getLayer2LockScriptHash(): Hash {
-    const accountScriptHash = utils.computeScriptHash(this.getLayer2LockScript());
-    debug("accountScriptHash", accountScriptHash);
-    return accountScriptHash;
+    return utils.computeScriptHash(this.getLayer2LockScript());
   }
 
   getLayer1Lock(): Script {
@@ -262,9 +260,7 @@ export default class DefaultLightGodwokenProvider implements LightGodwokenProvid
       args: ownerCKBLock.args,
       hash_type: ownerCKBLock.hash_type as HashType,
     };
-    const ownerLockHash = utils.computeScriptHash(ownerLock);
-    debug("ownerLockHash", ownerLockHash);
-    return ownerLockHash;
+    return utils.computeScriptHash(ownerLock);
   }
 
   async getLayer1Cell(outPoint: OutPoint): Promise<Cell | null> {

--- a/packages/light-godwoken/src/lightGodwokenType.ts
+++ b/packages/light-godwoken/src/lightGodwokenType.ts
@@ -115,12 +115,13 @@ export interface WithdrawResultWithCell extends WithdrawBase {
 }
 export interface WithdrawResultV1 extends WithdrawBase {
   layer1TxHash: HexString;
-  status: "pending" | "success" | "failed";
+  status: "pending" | "available" | "succeed" | "failed";
 }
 export interface WithdrawResultV0 extends WithdrawBase {
+  cell?: Cell;
   layer1TxHash: HexString;
   isFastWithdrawal: boolean;
-  status: "pending" | "success" | "failed";
+  status: "pending" | "available" | "succeed" | "failed";
 }
 
 export interface UnlockPayload {
@@ -237,7 +238,7 @@ export interface LightGodwokenBase {
 
 export interface LightGodwokenV0 extends LightGodwokenBase {
   getMinimalWithdrawalToV1Capacity(): BI;
-  // unlock: (payload: UnlockPayload) => Promise<Hash>;
+  unlock: (payload: UnlockPayload) => Promise<Hash>;
   withdrawToV1WithEvent: (payload: WithdrawalToV1EventEmitterPayload) => WithdrawalEventEmitter;
 }
 export interface LightGodwokenV1 extends LightGodwokenBase {}

--- a/packages/light-godwoken/src/schemas/codecV0.ts
+++ b/packages/light-godwoken/src/schemas/codecV0.ts
@@ -6,7 +6,7 @@ const { table, option, struct } = molecule;
 const { Bytes, Byte32 } = blockchain;
 const { Uint32, Uint128, Uint8, Uint64 } = number;
 
-export type RawWithdrwal = {
+export type RawWithdrawal = {
   nonce: number;
   capacity: BI;
   amount: BI;
@@ -21,7 +21,7 @@ export type RawWithdrwal = {
     amount: BI;
   };
 };
-export const RawWithdrwalCodec = struct(
+export const RawWithdrawalCodec = struct(
   {
     nonce: Uint32,
     capacity: Uint64,
@@ -57,7 +57,7 @@ export const WithdrawalRequestExtraCodec = table(
   {
     request: table(
       {
-        raw: RawWithdrwalCodec,
+        raw: RawWithdrawalCodec,
         signature: Bytes,
       },
       ["raw", "signature"],

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "light-godwoken-scripts",
+  "version": "0.1.1",
+  "private": true,
+  "dependencies": {
+    "ckb-js-toolkit": "^0.10.2",
+    "light-godwoken": "0.1.1"
+  },
+  "devDependencies": {
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.3"
+  },
+  "engines": {
+    "npm": "please-use-yarn",
+    "yarn": ">= 1.19.1"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "CommonJS"

--- a/scripts/v0/unlock.ts
+++ b/scripts/v0/unlock.ts
@@ -1,0 +1,178 @@
+import { LightGodwokenV0, EthereumProvider, LightGodwokenProvider } from "light-godwoken";
+import { predefinedConfigs, GodwokenNetwork, GodwokenVersion } from "light-godwoken";
+import { number, blockchain, createObjectCodec, enhancePack } from "@ckb-lumos/codec";
+import { Cell } from "@ckb-lumos/base";
+import { Reader } from "ckb-js-toolkit";
+
+const { Byte32 } = blockchain;
+const { Uint64, Uint128 } = number;
+const RawWithdrawalLockArgsCodec = createObjectCodec({
+  account_script_hash: Byte32,
+  withdrawal_block_hash: Byte32,
+  withdrawal_block_number: Uint64,
+  // buyer can pay sell_amount token to unlock
+  sudt_script_hash: Byte32,
+  sell_amount: Uint128,
+  sell_capacity: Uint64,
+  // layer1 lock to withdraw after challenge period
+  owner_lock_hash: Byte32,
+  // layer1 lock to receive the payment, must exists on the chain
+  payment_lock_hash: Byte32,
+});
+export const WithdrawalLockArgsCodec = enhancePack(
+  RawWithdrawalLockArgsCodec,
+  () => new Uint8Array(0),
+  (buf: Uint8Array) => ({
+    account_script_hash: buf.slice(0, 32),
+    withdrawal_block_hash: buf.slice(32, 64),
+    withdrawal_block_number: buf.slice(64, 72),
+    sudt_script_hash: buf.slice(72, 104),
+    sell_amount: buf.slice(104, 120),
+    sell_capacity: buf.slice(120, 128),
+    owner_lock_hash: buf.slice(128, 160),
+    payment_lock_hash: buf.slice(160, 192),
+  }),
+);
+
+// config
+// https://github.com/Flouse/godwoken-examples/blob/benchmark/packages/tools/src/benchmark/accounts.ts
+const privateKey = "0xf5e9bac200a2eca0b0eead8a327ef3dc148ba10e192d07badad2d195f2488b94";
+const config = predefinedConfigs.testnet.v0;
+
+/*
+available withdrawal cell
+{
+  cell_output: {
+    capacity: '0x62b85e900',
+    lock: {
+      args: '0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6ab6f642bafd4210557c25cbb0ced95fcb45c59071c41015ab5335f413b68c9aceffe7f68a0a8974165dcc33d856dd4da1e671e0feab29224b660e9f938d72b686316006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e40b5402000000f539266ebeebbc2084071b18e2659c6a46a21842ba60ec1e4f7787545be0c9490000000000000000000000000000000000000000000000000000000000000000',
+      code_hash: '0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5',
+      hash_type: 'type'
+    },
+    type: null
+  },
+  data: '0x',
+  out_point: {
+    index: '0x16',
+    tx_hash: '0xb563e5ee46e7cf71f1d9b408538f2ef54fa5c080ed0cedbe3899d7ee9300f5c7'
+  },
+  block_number: '0x59ad40'
+}
+*/
+
+async function createLightGodwoken() {
+  const ethereum = EthereumProvider.fromPrivateKey(config.layer2Config.GW_POLYJUICE_RPC_URL, privateKey);
+  const ethAddress = await ethereum.getAddress();
+
+  const lightGodwokenProvider = new LightGodwokenProvider({
+    network: GodwokenNetwork.Testnet,
+    version: GodwokenVersion.V0,
+    ethAddress,
+    ethereum,
+    config,
+  });
+
+  return new LightGodwokenV0(lightGodwokenProvider);
+}
+
+async function unlockCell(client: LightGodwokenV0, cell: Cell) {
+  try {
+    const txHash = await client.unlock({ cell });
+    console.log("unlock withdrawal cell succeed", txHash);
+  } catch (e) {
+    console.error("unlock withdrawal cell failed", e);
+  }
+}
+
+async function main() {
+  const client = await createLightGodwoken();
+  const targetAccountScriptHash = client.provider.getLayer2LockScriptHash();
+
+  const withdrawalLock = config.layer2Config.SCRIPTS.withdrawal_lock;
+  const collector = client.provider.ckbIndexer.collector({
+    argsLen: "any",
+    order: "desc",
+    lock: {
+      hash_type: "type",
+      code_hash: withdrawalLock.script_type_hash,
+      args: `${config.layer2Config.ROLLUP_CONFIG.rollup_type_hash}${targetAccountScriptHash.slice(2)}`,
+    },
+  });
+
+  const cells: Cell[] = [];
+  for await (const cell of collector.collect()) {
+    const withdrawalLockArgsData = `0x${cell.cell_output.lock.args.slice(66)}`;
+    const withdrawalLockArgs = WithdrawalLockArgsCodec.unpack(
+      new Uint8Array(new Reader(withdrawalLockArgsData).toArrayBuffer()),
+    );
+
+    if (cell.out_point) {
+      const latestFinalizedBlockNumber = await client.provider.getLastFinalizedBlockNumber();
+      const expectBlockNumber =
+        withdrawalLockArgs.withdrawal_block_number.toNumber() + config.layer2Config.FINALITY_BLOCKS;
+      if (latestFinalizedBlockNumber < expectBlockNumber) {
+        console.log("found matched cell, but it's not finalized yet");
+        continue;
+      }
+
+      const cellWithStatus = await client.provider.ckbRpc.get_live_cell(cell.out_point, false);
+      if (cellWithStatus.status !== "live") {
+        console.log("found matched cell, but it's already been transferred");
+        continue;
+      }
+
+      console.log("found matched live cell", cell);
+      cells.push(cell);
+    }
+  }
+
+  console.log(JSON.stringify(cells, null, 2));
+  console.log("cells count", cells.length);
+}
+
+async function mainUnlock() {
+  const client = await createLightGodwoken();
+  await unlockCell(client, {
+    cell_output: {
+      capacity: "0x62b85e900",
+      lock: {
+        args: "0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6ab6f642bafd4210557c25cbb0ced95fcb45c59071c41015ab5335f413b68c9aceffe7f68a0a8974165dcc33d856dd4da1e671e0feab29224b660e9f938d72b686316006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e40b5402000000f539266ebeebbc2084071b18e2659c6a46a21842ba60ec1e4f7787545be0c9490000000000000000000000000000000000000000000000000000000000000000",
+        code_hash: "0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5",
+        hash_type: "type",
+      },
+    },
+    data: "0x",
+    out_point: {
+      index: "0x16",
+      tx_hash: "0xb563e5ee46e7cf71f1d9b408538f2ef54fa5c080ed0cedbe3899d7ee9300f5c7",
+    },
+    block_number: "0x59ad40",
+  });
+}
+
+function explainCell() {
+  const cell: Cell = {
+    cell_output: {
+      capacity: "0x62b85e900",
+      lock: {
+        args: "0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6ab6f642bafd4210557c25cbb0ced95fcb45c59071c41015ab5335f413b68c9aceffe7f68a0a8974165dcc33d856dd4da1e671e0feab29224b660e9f938d72b686316006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e40b5402000000f539266ebeebbc2084071b18e2659c6a46a21842ba60ec1e4f7787545be0c9490000000000000000000000000000000000000000000000000000000000000000",
+        code_hash: "0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5",
+        hash_type: "type",
+      },
+    },
+    data: "0x",
+    out_point: {
+      index: "0x16",
+      tx_hash: "0xb563e5ee46e7cf71f1d9b408538f2ef54fa5c080ed0cedbe3899d7ee9300f5c7",
+    },
+    block_number: "0x59ad40",
+  };
+  const withdrawalLockArgsData = `0x${cell.cell_output.lock.args.slice(66)}`;
+  const withdrawalLockArgs = WithdrawalLockArgsCodec.unpack(
+    new Uint8Array(new Reader(withdrawalLockArgsData).toArrayBuffer()),
+  );
+
+  console.log(withdrawalLockArgs);
+}
+
+explainCell();


### PR DESCRIPTION
### Description
Some legacy(v0) withdrawal cells are still locked, and the current version of light-godwoken/godwoken-bridge doesn't provide this feature. This PR provides a unlock function in light-godwoken, and a unlock button in `mainnet_v0` of godwoken-bridge.

### Changes
- Feature: Add method/component to unlock legacy(v0) withdrawal cells
- Feature: Add script to test the unlock feature locally

### Checks
Please check the following list before merging the PR:
- [x] At least unlock an actual legacy withdrawal cell
- [x] Change the base branch to `develop`
