### PR TITLE
Feat: l1-transfer

### DIFF
--- a/apps/godwoken-bridge/src/App.tsx
+++ b/apps/godwoken-bridge/src/App.tsx
@@ -5,6 +5,7 @@ import { Provider as LightGodwokenProvider } from "./contexts/LightGodwokenConte
 import GodwokenBridge from "./views/GodwokenBridge";
 import Deposit from "./views/Deposit";
 import Withdrawal from "./views/withdrawal/Withdrawal";
+import L1Transfer from "./views/L1Transfer";
 
 function App() {
   const queryClient = new QueryClient();
@@ -24,6 +25,10 @@ function App() {
               <Route path="withdrawal">
                 <Route index element={<Navigate to="pending" />} />
                 <Route path=":status" element={<Withdrawal />} />
+              </Route>
+              <Route path="transfer">
+                <Route index element={<Navigate to="pending" />} />
+                <Route path=":status" element={<L1Transfer />} />
               </Route>
             </Route>
           </Routes>

--- a/apps/godwoken-bridge/src/components/Input/CurrencyInputPanel.tsx
+++ b/apps/godwoken-bridge/src/components/Input/CurrencyInputPanel.tsx
@@ -3,7 +3,7 @@ import { List, Tooltip } from "antd";
 import { FixedHeightRow } from "../Withdrawal/WithdrawalItemV0";
 import NumericalInput from "./NumericalInput";
 import { DownOutlined, LoadingOutlined, QuestionCircleOutlined } from "@ant-design/icons";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { getFullDisplayAmount } from "../../utils/formatTokenAmount";
 import { UniversalToken, translate } from "light-godwoken";
 import { BI } from "@ckb-lumos/lumos";
@@ -73,6 +73,7 @@ interface CurrencyInputPanelProps {
   balancesList: string[] | undefined;
   tokenList: UniversalToken[] | undefined;
   dataLoading: boolean;
+  selected?: UniversalToken;
   onSelectedChange: (value: UniversalToken, balance: string) => void;
 }
 export default function CurrencyInputPanel({
@@ -83,6 +84,7 @@ export default function CurrencyInputPanel({
   balancesList,
   tokenList,
   dataLoading,
+  selected,
   onSelectedChange,
 }: CurrencyInputPanelProps) {
   const lightGodwoken = useLightGodwoken();
@@ -115,12 +117,30 @@ export default function CurrencyInputPanel({
       }
     });
 
+  const selectedTokenWithBalance = useMemo(() => {
+    if (!selected) return undefined;
+    return tokenListWithBalanceSorted.find((row) => row.uan === selected.uan);
+  }, [tokenListWithBalanceSorted, selected]);
+
   useEffect(() => {
-    setCurrencyBalance(undefined);
-    setSelectedCurrency(undefined);
-    setDisableInput(true);
+    if (selectedTokenWithBalance) {
+      setCurrencyBalance(selectedTokenWithBalance?.balance);
+      setSelectedCurrency(selected);
+      setDisableInput(false);
+    } else {
+      setSelectedCurrency(undefined);
+      setCurrencyBalance(undefined);
+      setDisableInput(true);
+    }
+  }, [
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lightGodwoken?.getVersion(), lightGodwoken?.provider.getL2Address()]);
+    lightGodwoken?.provider.getL2Address(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    lightGodwoken?.getVersion(),
+    selectedTokenWithBalance,
+    selected,
+  ]);
+
   const handleOk = () => {
     setIsModalVisible(false);
   };

--- a/apps/godwoken-bridge/src/components/Input/GeneralInputPanel.tsx
+++ b/apps/godwoken-bridge/src/components/Input/GeneralInputPanel.tsx
@@ -1,0 +1,85 @@
+import React, { ChangeEvent } from "react";
+import { InputCard, Text, Row } from "../../style/common";
+import styled from "styled-components";
+
+const StyledInput = styled.input<{ error?: boolean; fontSize?: string; align?: string }>`
+  padding: 0;
+  width: 0;
+  position: relative;
+  font-weight: 500;
+  outline: none;
+  border: none;
+  flex: 1 1 auto;
+  background-color: transparent;
+  font-size: 16px;
+  text-align: ${({ align }) => align && align};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-appearance: textfield;
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  [type="text"] {
+    -moz-appearance: textfield;
+  }
+
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
+
+  :disabled {
+    cursor: not-allowed;
+  }
+`;
+
+export interface GeneralInputPanelProps {
+  value: string;
+  onUserInput: (value: string) => void;
+  label?: string;
+  maxAmount?: string;
+  CKBBalance?: string;
+  isLoading?: boolean;
+  decimals?: number;
+  placeholder?: string;
+}
+
+export default function GeneralInputPanel({
+  value,
+  onUserInput,
+  label,
+  isLoading,
+  placeholder,
+}: GeneralInputPanelProps) {
+  function onInput(event: ChangeEvent<HTMLInputElement>) {
+    onUserInput(event.target.value);
+  }
+
+  return (
+    <InputCard>
+      <Row className="first-row">
+        <Text>{label}</Text>
+      </Row>
+      <Row className="second-row">
+        <StyledInput
+          className="token-amount-input"
+          value={value}
+          onInput={onInput}
+          // text input options
+          inputMode="text"
+          title={label}
+          autoComplete="off"
+          autoCorrect="off"
+          // text-specific options
+          type="text"
+          placeholder={placeholder}
+          minLength={1}
+          spellCheck="false"
+        />
+      </Row>
+    </InputCard>
+  );
+}

--- a/apps/godwoken-bridge/src/components/L1Transfer/L1TransferItem.tsx
+++ b/apps/godwoken-bridge/src/components/L1Transfer/L1TransferItem.tsx
@@ -1,0 +1,160 @@
+import styled from "styled-components";
+import React, { useMemo } from "react";
+import { BI } from "@ckb-lumos/lumos";
+import { L1TxHistoryInterface } from "../../hooks/useL1TxHistory";
+import { useLightGodwoken } from "../../hooks/useLightGodwoken";
+import { getDisplayAmount } from "../../utils/formatTokenAmount";
+import { ReactComponent as CKBIcon } from "../../assets/ckb.svg";
+import { CheckCircleOutlined, ExclamationCircleOutlined, QuestionCircleOutlined } from "@ant-design/icons";
+import { ArrowRightAltTwotone } from "@ricons/material";
+import { Icon } from "@ricons/utils";
+import { MainText } from "../../style/common";
+import { COLOR } from "../../style/variables";
+import { Tooltip } from "antd";
+
+const L1TransferItemStyleWrapper = styled.div`
+  padding: 16px;
+  border-radius: 12px;
+  background: #f3f3f3;
+
+  & + & {
+    margin-top: 16px;
+  }
+
+  .main-row {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    font-weight: 400;
+    line-height: 1.5;
+    font-size: 14px;
+    flex-wrap: wrap;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+  .amount {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    .ckb-amount,
+    .sudt-amount {
+      img,
+      svg {
+        width: 22px;
+        height: 22px;
+        margin-right: 5px;
+      }
+    }
+    .ckb-amount {
+      display: flex;
+      align-items: center;
+
+      .ckb-icon {
+        display: flex;
+        align-items: center;
+      }
+    }
+    .sudt-amount {
+      display: flex;
+      align-items: center;
+    }
+    .sudt-amount + .ckb-amount {
+      margin-top: 10px;
+    }
+    .address {
+      display: flex;
+      align-items: center;
+      margin-top: 10px;
+
+      .address-icon {
+        display: inline-flex;
+        margin-right: 5px;
+        width: 22px;
+        height: 22px;
+        font-size: 24px;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+  }
+  .right-side {
+    height: 40px;
+    display: flex;
+    align-self: center;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+
+export interface L1TransferItemProps extends L1TxHistoryInterface {}
+
+export default function L1TransferItem(props: L1TransferItemProps) {
+  const lightGodwoken = useLightGodwoken();
+
+  const { capacity, amount, token, recipient, status } = props;
+  const transferredSudt = useMemo(() => BI.from(amount).gt(0) && token !== void 0, [amount, token]);
+  const ckbAmount = useMemo(() => `${getDisplayAmount(BI.from(capacity), 8)} CKB`, [capacity]);
+  const sudtAmount = useMemo(() => {
+    if (!transferredSudt) return "";
+    return `${getDisplayAmount(BI.from(amount), token!.decimals)} ${token!.symbol}`;
+  }, [transferredSudt, amount, token]);
+  const shortenRecipient = useMemo(() => (recipient ? truncateMiddle(recipient, 11, 11) : ""), [recipient]);
+
+  function truncateMiddle(str: string, first = 40, last = 6) {
+    return str.substring(0, first) + "..." + str.substring(str.length - last);
+  }
+  function toExplorer() {
+    if (!lightGodwoken) return;
+    const config = lightGodwoken.getConfig();
+    window.open(`${config.layer1Config.SCANNER_URL}/transaction/${props.txHash}`, "_blank");
+  }
+
+  return (
+    <L1TransferItemStyleWrapper>
+      <div className="main-row" onClick={toExplorer}>
+        <div className="amount">
+          {transferredSudt && (
+            <div className="sudt-amount">
+              {token?.tokenURI ? <img src={token?.tokenURI} alt="" /> : ""}
+              <MainText>{sudtAmount}</MainText>
+            </div>
+          )}
+          {!transferredSudt && (
+            <div className="ckb-amount">
+              <div className="ckb-icon">
+                <CKBIcon />
+              </div>
+              <MainText>{ckbAmount}</MainText>
+            </div>
+          )}
+          <div className="address">
+            <div className="address-icon">
+              <Icon>
+                <ArrowRightAltTwotone />
+              </Icon>
+            </div>
+            <MainText>{shortenRecipient}</MainText>
+          </div>
+        </div>
+        <div className="right-side">
+          {status === "pending" && (
+            <Tooltip title="Transaction committing">
+              <QuestionCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />
+            </Tooltip>
+          )}
+          {status === "success" && (
+            <Tooltip title={status}>
+              <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />
+            </Tooltip>
+          )}
+          {status === "rejected" && (
+            <Tooltip title="Transaction has been rejected">
+              <ExclamationCircleOutlined style={{ color: COLOR.error, height: "21px", lineHeight: "21px" }} />
+            </Tooltip>
+          )}
+        </div>
+      </div>
+    </L1TransferItemStyleWrapper>
+  );
+}

--- a/apps/godwoken-bridge/src/components/L1Transfer/L1TransferList.tsx
+++ b/apps/godwoken-bridge/src/components/L1Transfer/L1TransferList.tsx
@@ -1,0 +1,121 @@
+import styled from "styled-components";
+import { LinkList, Tab } from "../../style/common";
+import React, { useEffect, useMemo, useState } from "react";
+import { useLightGodwoken } from "../../hooks/useLightGodwoken";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { useGodwokenVersion } from "../../hooks/useGodwokenVersion";
+import { useL1TxHistory } from "../../hooks/useL1TxHistory";
+import { Placeholder } from "../Placeholder";
+import L1TransferItem from "./L1TransferItem";
+import { L1TransactionEventEmitter, L1TransactionRejectedError, LightGodwokenError } from "light-godwoken";
+
+const L1TransferListStyleWrapper = styled.div`
+  border-bottom-left-radius: 24px;
+  border-bottom-right-radius: 24px;
+  .list {
+    max-height: 500px;
+    min-height: 50px;
+    overflow-y: auto;
+  }
+`;
+
+export default function L1TransferList() {
+  const lightGodwoken = useLightGodwoken();
+  const godwokenVersion = useGodwokenVersion();
+  const l1Address = lightGodwoken?.provider.getL1Address();
+
+  // tx history
+  const storeKey = `${godwokenVersion}/${l1Address}/transfer`;
+  const { txHistory, updateTxWithStatus, removeTxWithTxHashes } = useL1TxHistory(storeKey);
+
+  // route
+  const params = useParams();
+  const navigate = useNavigate();
+  const isPending = params.status === "pending";
+  const isCompleted = params.status === "completed";
+  function navigateStatus(targetStatus: "pending" | "completed") {
+    navigate(`/${params.version}/transfer/${targetStatus}`);
+  }
+
+  const pendingList = useMemo(() => txHistory.filter((row) => row.status === "pending"), [txHistory]);
+  const completedList = useMemo(() => txHistory.filter((row) => row.status !== "pending"), [txHistory]);
+  const pendingTxHashes = useMemo(() => pendingList.map((row) => row.txHash), [pendingList]);
+  const completedTxHashes = useMemo(() => completedList.map((row) => row.txHash), [completedList]);
+
+  useEffect(() => {
+    if (completedTxHashes.length > 15) {
+      const oldTxHashes = completedTxHashes.slice(15);
+      removeTxWithTxHashes(oldTxHashes);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [completedTxHashes]);
+
+  const [pendingListener, setPendingListener] = useState<L1TransactionEventEmitter>();
+  useEffect(
+    () => {
+      if (!lightGodwoken) return;
+      if (!pendingTxHashes.length) return;
+
+      const listener = lightGodwoken!.subscribePendingL1Transactions(pendingTxHashes);
+      listener.on("success", (txHash) => {
+        updateTxWithStatus(txHash, "success");
+      });
+      listener.on("fail", (e) => {
+        if (e instanceof L1TransactionRejectedError) {
+          updateTxWithStatus(e.metadata, "rejected");
+        } else if (e instanceof LightGodwokenError) {
+          updateTxWithStatus(e.metadata, "fail");
+        } else {
+          console.error("Unknown L1 transaction error:", e);
+        }
+      });
+
+      setPendingListener(listener);
+      return () => {
+        pendingListener?.removeAllListeners?.();
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [lightGodwoken, godwokenVersion, pendingTxHashes],
+  );
+
+  if (!isPending && !isCompleted) {
+    return <Navigate to={`/${params.version}/transfer/pending`} />;
+  }
+  if (!lightGodwoken) {
+    return (
+      <L1TransferListStyleWrapper>
+        <Placeholder />
+      </L1TransferListStyleWrapper>
+    );
+  }
+
+  return (
+    <L1TransferListStyleWrapper>
+      <LinkList>
+        <Tab className={isPending ? "active" : ""} onClick={() => navigateStatus("pending")}>
+          Pending
+        </Tab>
+        <Tab className={isCompleted ? "active" : ""} onClick={() => navigateStatus("completed")}>
+          Completed
+        </Tab>
+      </LinkList>
+      {isPending && (
+        <div className="list pending-list">
+          {pendingList.length === 0 && "There is no pending transfers here"}
+          {pendingList.map((props, index) => (
+            <L1TransferItem {...props} key={index} />
+          ))}
+        </div>
+      )}
+      {isCompleted && (
+        <div className="list completed-list">
+          {completedList.length === 0 && "There is no completed transfers here"}
+          {completedList.map((props, index) => (
+            <L1TransferItem {...props} key={index} />
+          ))}
+        </div>
+      )}
+    </L1TransferListStyleWrapper>
+  );
+}

--- a/apps/godwoken-bridge/src/components/L1Transfer/RequestL1Transfer.tsx
+++ b/apps/godwoken-bridge/src/components/L1Transfer/RequestL1Transfer.tsx
@@ -1,0 +1,269 @@
+import styled from "styled-components";
+import CkbSvg, { ReactComponent as CKBIcon } from "../../assets/ckb.svg";
+import { BI } from "@ckb-lumos/lumos";
+import { HashType } from "@ckb-lumos/base";
+import { notification } from "antd";
+import {
+  L1TransactionRejectedError,
+  NotEnoughCapacityError,
+  NotEnoughSudtError,
+  SUDT,
+  TransactionSignError,
+  UniversalToken,
+} from "light-godwoken";
+import React, { useEffect, useMemo, useState } from "react";
+import { getL1TransferInputError } from "../../utils/inputValidate";
+import { useLightGodwoken } from "../../hooks/useLightGodwoken";
+import { useL1CKBBalance } from "../../hooks/useL1CKBBalance";
+import { useSUDTBalance } from "../../hooks/useSUDTBalance";
+import CurrencyInputPanel from "../Input/CurrencyInputPanel";
+import GeneralInputPanel from "../Input/GeneralInputPanel";
+import { ConfirmModal, InputInfo, LoadingWrapper, MainText, PrimaryButton, Tips } from "../../style/common";
+import { ArrowDownwardFilled } from "@ricons/material";
+import { Icon } from "@ricons/utils";
+import { formatToThousands, parseStringToBI } from "../../utils/numberFormat";
+import { LoadingOutlined } from "@ant-design/icons";
+import { getFullDisplayAmount } from "../../utils/formatTokenAmount";
+import { captureException } from "@sentry/react";
+import { useL1TxHistory } from "../../hooks/useL1TxHistory";
+import { useGodwokenVersion } from "../../hooks/useGodwokenVersion";
+
+const CkbAsSudt: SUDT = {
+  name: "CKB",
+  symbol: "CKB",
+  uan: "CKB.ckb",
+  decimals: 8,
+  tokenURI: CkbSvg,
+  type: {
+    hash_type: "0x" as HashType,
+    code_hash: "0x",
+    args: "0x",
+  },
+};
+
+const RequestL1TransferStyleWrapper = styled.div`
+  .icon-container {
+    padding: 7px 0;
+    display: flex;
+    justify-content: center;
+    font-size: 16px;
+  }
+`;
+const ModalContent = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export default function RequestL1Transfer() {
+  const lightGodwoken = useLightGodwoken();
+  const godwokenVersion = useGodwokenVersion();
+  const l1Address = lightGodwoken?.provider.getL1Address();
+
+  // tx history
+  const storeKey = lightGodwoken ? `${godwokenVersion}/${l1Address}/transfer` : null;
+  const { addTxToHistory } = useL1TxHistory(storeKey);
+
+  // selected currency
+  const [amount, setAmount] = useState("");
+  const [selected, setSelected] = useState<SUDT>(CkbAsSudt);
+  const [selectedBalance, setSelectedBalance] = useState<string>();
+  const isSelectedCkb = useMemo(() => selected?.uan === CkbAsSudt.uan, [selected]);
+  function onSelectedChanged(value: UniversalToken, balance: string) {
+    setSelected(value as SUDT);
+    setSelectedBalance(balance);
+  }
+
+  // recipient address
+  const [recipient, setRecipient] = useState("");
+  useEffect(() => {
+    setAmount("");
+    setSelected(CkbAsSudt);
+    setRecipient("");
+  }, [lightGodwoken, godwokenVersion, addTxToHistory]);
+
+  // ckb balance
+  const ckbBalanceQuery = useL1CKBBalance();
+  useEffect(() => {
+    if (isSelectedCkb && ckbBalanceQuery.data) {
+      setSelectedBalance(ckbBalanceQuery.data);
+    }
+  }, [isSelectedCkb, ckbBalanceQuery.data]);
+
+  // currency list
+  const tokenList = useMemo(() => [CkbAsSudt, ...(lightGodwoken?.getBuiltinSUDTList() ?? [])], [lightGodwoken]);
+
+  // sudt balances (combined with ckb balance)
+  const sudtBalanceQuery = useSUDTBalance();
+
+  // currency balances
+  const currencyBalanceLoading = useMemo(
+    () => ckbBalanceQuery.isLoading || sudtBalanceQuery.isLoading,
+    [ckbBalanceQuery.isLoading, sudtBalanceQuery.isLoading],
+  );
+  const currencyBalanceList = useMemo(() => {
+    if (currencyBalanceLoading) return void 0;
+    return [ckbBalanceQuery.data ?? "0x0", ...(sudtBalanceQuery.data?.balances ?? [])];
+  }, [currencyBalanceLoading, ckbBalanceQuery.data, sudtBalanceQuery.data]);
+
+  const inputError = useMemo(() => {
+    if (!lightGodwoken) {
+      return "Wallet Not Connected";
+    }
+    return getL1TransferInputError({
+      ckbValue: isSelectedCkb ? amount : "",
+      ckbBalance: ckbBalanceQuery.data,
+      sudtValue: !isSelectedCkb ? amount : "",
+      sudtBalance: !isSelectedCkb ? selectedBalance : void 0,
+      sudtSymbol: !isSelectedCkb ? selected.symbol : void 0,
+      sudtDecimals: !isSelectedCkb ? selected.decimals : void 0,
+      recipientAddress: recipient,
+      senderAddress: lightGodwoken.provider.l1Address,
+      config: lightGodwoken!.getConfig(),
+    });
+  }, [amount, ckbBalanceQuery.data, isSelectedCkb, lightGodwoken, recipient, selected, selectedBalance]);
+
+  const [modalVisible, setModalVisible] = useState(false);
+  useEffect(() => setModalVisible(false), [lightGodwoken]);
+
+  async function l1Transfer() {
+    if (!lightGodwoken) {
+      throw new Error("LightGodwoken not found");
+    }
+
+    setModalVisible(true);
+    try {
+      const isSelectedSudt = !isSelectedCkb && selected;
+      const decimals = isSelectedSudt ? selected.decimals : 8;
+      const parsedAmount = parseStringToBI(amount, decimals);
+      const txHash = await lightGodwoken.l1Transfer({
+        amount: parsedAmount.toHexString(),
+        sudtType: isSelectedSudt ? selected.type : void 0,
+        toAddress: recipient.trim(),
+      });
+
+      addTxToHistory({
+        txHash,
+        type: "transfer",
+        status: "pending",
+        recipient: recipient.trim(),
+        capacity: isSelectedCkb ? parsedAmount.toString() : "0",
+        amount: isSelectedSudt ? parsedAmount.toString() : "0",
+        token: isSelectedSudt ? selected : void 0,
+        symbol: isSelectedSudt ? selected.symbol : void 0,
+        decimals: isSelectedSudt ? selected.decimals : void 0,
+      });
+    } catch (e) {
+      handleError(e, selected);
+    } finally {
+      setModalVisible(false);
+    }
+  }
+
+  function handleError(e: unknown, selectedSudt?: SUDT) {
+    console.error(e);
+    if (e instanceof NotEnoughCapacityError) {
+      const expect = formatToThousands(getFullDisplayAmount(BI.from(e.metadata.expected), 8, { maxDecimalPlace: 8 }));
+      const actual = formatToThousands(getFullDisplayAmount(BI.from(e.metadata.actual), 8, { maxDecimalPlace: 8 }));
+      notification.error({
+        message: `Expected ${expect} CKB but only got ${actual} CKB`,
+      });
+      return;
+    }
+    if (e instanceof NotEnoughSudtError) {
+      const expect = formatToThousands(
+        getFullDisplayAmount(BI.from(e.metadata.expected), selectedSudt?.decimals, {
+          maxDecimalPlace: selectedSudt?.decimals,
+        }),
+      );
+      const actual = formatToThousands(
+        getFullDisplayAmount(BI.from(e.metadata.actual), selectedSudt?.decimals, {
+          maxDecimalPlace: selectedSudt?.decimals,
+        }),
+      );
+      notification.error({
+        message: `Expected ${expect} ${selectedSudt?.symbol} but only got ${actual} ${selectedSudt?.symbol}`,
+      });
+      return;
+    }
+    if (e instanceof TransactionSignError) {
+      notification.error({
+        message: `User denied message signature`,
+      });
+      return;
+    }
+    if (e instanceof L1TransactionRejectedError) {
+      const txHash = e.metadata;
+      const explorerUrl = lightGodwoken?.getConfig().layer1Config.SCANNER_URL;
+      notification.error({
+        message: `Tx(${txHash}) rejected, click to view details in the explorer`,
+        onClick: () => window.open(`${explorerUrl}/transaction/${txHash}`, "_blank"),
+      });
+    }
+
+    captureException(e);
+    notification.error({
+      message: `Unknown Error, Please try again later`,
+    });
+  }
+
+  return (
+    <RequestL1TransferStyleWrapper>
+      <CurrencyInputPanel
+        label="Transfer"
+        value={amount}
+        onUserInput={setAmount}
+        tokenList={tokenList}
+        selected={selected}
+        onSelectedChange={onSelectedChanged}
+        balancesList={currencyBalanceList}
+        dataLoading={sudtBalanceQuery.isLoading}
+      />
+      <div className="icon-container">
+        <Icon>
+          <ArrowDownwardFilled />
+        </Icon>
+      </div>
+      <GeneralInputPanel label="Recipient" placeholder="CKB Address" value={recipient} onUserInput={setRecipient} />
+      <PrimaryButton disabled={!amount || inputError !== void 0} onClick={l1Transfer}>
+        {inputError || "Transfer"}
+      </PrimaryButton>
+      <ConfirmModal
+        title="Confirm Transaction"
+        visible={modalVisible}
+        onCancel={() => setModalVisible(false)}
+        footer={null}
+        width={400}
+      >
+        <ModalContent>
+          <InputInfo>
+            <span className="title">Transferring</span>
+            <div className="amount">
+              {isSelectedCkb && (
+                <div className="ckb-amount">
+                  <MainText>{formatToThousands(amount)}</MainText>
+                  <div className="ckb-icon">
+                    <CKBIcon></CKBIcon>
+                  </div>
+                  <MainText>CKB</MainText>
+                </div>
+              )}
+              {!isSelectedCkb && selected && (
+                <div className="sudt-amount">
+                  <MainText>{formatToThousands(amount)}</MainText>
+                  {selected.tokenURI && <img src={selected.tokenURI} alt="" />}
+                  <MainText>{selected.symbol}</MainText>
+                </div>
+              )}
+            </div>
+          </InputInfo>
+          <LoadingWrapper>
+            <LoadingOutlined />
+          </LoadingWrapper>
+          <Tips>Waiting for User Confirmation</Tips>
+        </ModalContent>
+      </ConfirmModal>
+    </RequestL1TransferStyleWrapper>
+  );
+}

--- a/apps/godwoken-bridge/src/components/Layout/PageFooter.tsx
+++ b/apps/godwoken-bridge/src/components/Layout/PageFooter.tsx
@@ -9,20 +9,20 @@ import { isMainnet } from "../../utils/environment";
 const StyledPage = styled.div`
   position: fixed;
   bottom: 0;
-  height: 48px;
+  height: 60px;
   width: 100%;
-  padding: 16px 8px;
+  padding: 8px 8px 16px 8px;
   display: flex;
   justify-content: end;
   align-items: center;
   background: white;
   margin-top: 24px;
-  @media (min-width: 600px) {
+  @media (min-width: 1024px) {
     display: none;
   }
 `;
 
-const PageFooter: React.FC = () => {
+export default function PageFooter() {
   const [popoverVisible, setPopoverVisible] = useState(false);
 
   useEffect(() => {
@@ -43,20 +43,18 @@ const PageFooter: React.FC = () => {
   };
   return (
     <StyledPage>
-      <VersionSelect></VersionSelect>
+      <VersionSelect />
       {!isMainnet && (
         <Popover
-          content={() => <PopoverMenu handleClick={closePopoverMenu}></PopoverMenu>}
           trigger="click"
+          placement="bottomLeft"
           overlayClassName="popover-menu"
           visible={popoverVisible}
-          placement="bottomLeft"
+          content={() => <PopoverMenu handleClick={closePopoverMenu} />}
         >
-          <Hamburger className="hamburger-menu-bottom" onClick={openPopoverMenu}></Hamburger>
+          <Hamburger className="hamburger-menu-bottom" onClick={openPopoverMenu} />
         </Popover>
       )}
     </StyledPage>
   );
-};
-
-export default PageFooter;
+}

--- a/apps/godwoken-bridge/src/components/Layout/PageHeader.tsx
+++ b/apps/godwoken-bridge/src/components/Layout/PageHeader.tsx
@@ -8,23 +8,28 @@ import { PopoverMenu } from "../PopoverMenu";
 import { VersionSelect } from "../VersionSelect";
 import { isMainnet } from "../../utils/environment";
 import { matchPath, useLocation, useNavigate, useParams } from "react-router-dom";
+
 const StyledPage = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
   padding: 16px 100px;
-  height: 64px;
+  min-height: 64px;
   margin-bottom: 24px;
   background: white;
   color: black;
   .logo-container {
     width: 182px;
+    flex: 1;
   }
   .link-list {
+    flex: 1;
     display: flex;
+    justify-content: center;
   }
   .right-side {
+    flex: 1;
     display: flex;
     justify-content: end;
     > &:hover {
@@ -34,8 +39,19 @@ const StyledPage = styled.div`
   .hamburger-menu {
     cursor: pointer;
   }
-  @media (max-width: 600px) {
+  @media (max-width: 1024px) {
     padding: 16px 8px;
+    flex-direction: column;
+
+    .logo-container {
+      display: flex;
+      justify-content: center;
+    }
+    .link-list {
+      margin-top: 12px;
+      padding-top: 16px;
+      border-top: 1px solid #eee;
+    }
     .right-side {
       display: none;
     }
@@ -50,7 +66,7 @@ const Link = styled.span`
   text-align: center;
   color: black;
   border-radius: 8px;
-  @media (max-width: 600px) {
+  @media (max-width: 1024px) {
     width: 100px;
     .right-side {
       display: none;
@@ -64,37 +80,34 @@ const Link = styled.span`
   }
 `;
 
+enum HeaderPaths {
+  Deposit = "deposit",
+  Withdrawal = "withdrawal",
+  L1Transfer = "transfer",
+}
+
 export default function PageHeader() {
   const location = useLocation();
-  const isDeposit = useMemo(() => {
-    return matchPath("/:version/deposit/*", location.pathname) !== null;
-  }, [location.pathname]);
-  const isWithdrawal = useMemo(() => {
-    return matchPath("/:version/withdrawal/*", location.pathname) !== null;
+  const currentPath = useMemo(() => {
+    return (
+      Object.values(HeaderPaths).find((path) => {
+        return matchPath(`/:version/${path}/*`, location.pathname) !== null;
+      }) ?? null
+    );
   }, [location.pathname]);
 
   const params = useParams();
   const navigate = useNavigate();
-  function changeViewToDeposit() {
-    navigate(`/${params.version}/deposit`);
-  }
-  function changeViewToWithdrawal() {
-    navigate(`/${params.version}/withdrawal`);
+  function toRoute(path: HeaderPaths) {
+    navigate(`/${params.version}/${path}`);
   }
 
   const [popoverVisible, setPopoverVisible] = useState(false);
-  function openPopoverMenu() {
-    setPopoverVisible(true);
-  }
-  function closePopoverMenu() {
-    setPopoverVisible(false);
-  }
-
   useEffect(() => {
     document.addEventListener("click", (e) => {
       const target = document.querySelector(".hamburger-menu");
       if (!(e.target && e.target instanceof Element && (e.target === target || target?.contains(e.target)))) {
-        closePopoverMenu();
+        setPopoverVisible(false);
       }
     });
   });
@@ -102,27 +115,39 @@ export default function PageHeader() {
   return (
     <StyledPage>
       <div className="logo-container">
-        <Logo height={27}></Logo>
+        <Logo height={27} />
       </div>
       <div className="link-list">
-        <Link onClick={changeViewToDeposit} className={isDeposit ? "active" : ""}>
+        <Link
+          className={currentPath === HeaderPaths.Deposit ? "active" : ""}
+          onClick={() => toRoute(HeaderPaths.Deposit)}
+        >
           Deposit
         </Link>
-        <Link onClick={changeViewToWithdrawal} className={isWithdrawal ? "active" : ""}>
+        <Link
+          className={currentPath === HeaderPaths.Withdrawal ? "active" : ""}
+          onClick={() => toRoute(HeaderPaths.Withdrawal)}
+        >
           Withdrawal
+        </Link>
+        <Link
+          className={currentPath === HeaderPaths.L1Transfer ? "active" : ""}
+          onClick={() => toRoute(HeaderPaths.L1Transfer)}
+        >
+          L1 Transfer
         </Link>
       </div>
       <div className="right-side">
-        <VersionSelect></VersionSelect>
+        <VersionSelect />
         {!isMainnet && (
           <Popover
-            content={() => <PopoverMenu handleClick={closePopoverMenu}></PopoverMenu>}
             trigger="click"
+            placement="bottomLeft"
             overlayClassName="popover-menu"
             visible={popoverVisible}
-            placement="bottomLeft"
+            content={() => <PopoverMenu handleClick={() => setPopoverVisible(false)} />}
           >
-            <Hamburger className="hamburger-menu" onClick={openPopoverMenu}></Hamburger>
+            <Hamburger className="hamburger-menu" onClick={() => setPopoverVisible(true)} />
           </Popover>
         )}
       </div>

--- a/apps/godwoken-bridge/src/index.css
+++ b/apps/godwoken-bridge/src/index.css
@@ -41,7 +41,7 @@ code {
 .ant-popover-arrow {
   display: none;
 }
-@media (max-width: 600px) {
+@media (max-width: 1024px) {
   .ant-popover.popover-menu {
     padding-bottom: 13px;
   }

--- a/apps/godwoken-bridge/src/style/common.ts
+++ b/apps/godwoken-bridge/src/style/common.ts
@@ -3,22 +3,23 @@ import styled from "styled-components";
 import { COLOR } from "./variables";
 
 export const Card = styled.div`
-  width: 400px;
-  background: white;
-  border-radius: 24px;
-  color: black;
   padding: 24px;
   margin-bottom: 16px;
-  @media (max-width: 600px) {
-    width: calc(100% - 8px);
-    margin: 16px 4px 64px;
+  width: 400px;
+  color: black;
+  background: white;
+  border-radius: 24px;
+  @media (max-width: 768px) {
+    width: 100%;
   }
 `;
 export const PageContent = styled.div`
-  width: 400px;
-  @media (max-width: 600px) {
-    width: calc(100% - 16px);
-  }
+  padding: 0 16px;
+  margin-bottom: 70px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
 `;
 export const Text = styled.span`
   font-size: 12px;
@@ -279,7 +280,7 @@ export const Tab = styled.span`
   text-align: center;
   color: black;
   border-radius: 8px;
-  @media (max-width: 600px) {
+  @media (max-width: 1024px) {
     width: 100px;
     .right-side {
       display: none;

--- a/apps/godwoken-bridge/src/utils/inputValidate.ts
+++ b/apps/godwoken-bridge/src/utils/inputValidate.ts
@@ -1,5 +1,7 @@
-import { BI } from "@ckb-lumos/lumos";
+import { Address, BI } from "@ckb-lumos/lumos";
+import { parseAddress } from "@ckb-lumos/helpers";
 import { parseStringToBI } from "./numberFormat";
+import { LightGodwokenConfig } from "light-godwoken";
 
 export const isSudtInputValidate = (sudtValue: string, sudtBalance?: string, decimal?: number) => {
   if (sudtValue === "0" || sudtValue === "") {
@@ -108,5 +110,73 @@ export const getDepositInputError = ({
   ) {
     return "Must Left 0 Or 64 More CKB";
   }
+  return undefined;
+};
+
+export interface L1TransferInputParams {
+  ckbValue: string;
+  ckbBalance?: string;
+  sudtValue: string;
+  sudtBalance?: string;
+  sudtDecimals?: number;
+  sudtSymbol?: string;
+  senderAddress: Address;
+  recipientAddress: Address;
+  config: LightGodwokenConfig;
+}
+
+export const getL1TransferInputError = (params: L1TransferInputParams): string | undefined => {
+  const minCkbCell = "63";
+  const minCkbCellShannons = parseStringToBI(minCkbCell, 8);
+  const minCkbCellWithFee = "64";
+  const minCkbCellWithFeeShannons = parseStringToBI(minCkbCellWithFee, 8);
+  const minSudtCell = "144";
+  const minSudtCellShannons = parseStringToBI(minSudtCell, 8);
+
+  const ckbAmount = parseStringToBI(params.ckbValue || "0", 8);
+  const ckbBalance = parseStringToBI(params.ckbBalance || "0");
+  if (!params.ckbValue && !params.sudtValue) {
+    return `Enter Transfer Amount`;
+  }
+  if (params.ckbValue && ckbAmount.lt(minCkbCellShannons)) {
+    return `Minimum ${minCkbCell} CKB`;
+  }
+  if (ckbBalance.lt(ckbAmount.add(minCkbCellWithFeeShannons))) {
+    return `Balance Less Than ${minCkbCellWithFee} CKB`;
+  }
+
+  const sudtAmount = parseStringToBI(params.sudtValue || "0", params.sudtDecimals);
+  const sudtBalance = parseStringToBI(params.sudtBalance || "0");
+  const sudtLeft = sudtBalance.sub(sudtAmount);
+  if (params.sudtValue && sudtAmount.lte(0)) {
+    return `Enter An Amount`;
+  }
+  if (params.sudtValue && sudtAmount.gt(sudtBalance)) {
+    return `Insufficient ${params.sudtSymbol} Amount`;
+  }
+
+  const minSudtExchange = BI.from(minCkbCellWithFee).add(minSudtCell);
+  const minSudtExchangeShannons = minCkbCellWithFeeShannons.add(minSudtCellShannons);
+  if (params.sudtValue && sudtLeft.gt(0) && ckbBalance.lt(minSudtExchangeShannons)) {
+    return `Balance Less Than ${minSudtExchange.toString()} CKB`;
+  }
+
+  const hasAmount = params.ckbValue || params.sudtValue;
+  const recipient = params.recipientAddress.trim();
+  const sender = params.senderAddress.trim();
+  if (hasAmount && !recipient) {
+    return "Enter Recipient Address";
+  }
+  try {
+    parseAddress(recipient, {
+      config: params.config.lumosConfig,
+    });
+  } catch {
+    return "Invalid CKB Address";
+  }
+  if (hasAmount && recipient === sender) {
+    return "Unsupported Self Transfer";
+  }
+
   return undefined;
 };

--- a/apps/godwoken-bridge/src/utils/inputValidate.ts
+++ b/apps/godwoken-bridge/src/utils/inputValidate.ts
@@ -126,12 +126,12 @@ export interface L1TransferInputParams {
 }
 
 export const getL1TransferInputError = (params: L1TransferInputParams): string | undefined => {
-  const minCkbCell = "63";
-  const minCkbCellShannons = parseStringToBI(minCkbCell, 8);
-  const minCkbCellWithFee = "64";
-  const minCkbCellWithFeeShannons = parseStringToBI(minCkbCellWithFee, 8);
-  const minSudtCell = "144";
-  const minSudtCellShannons = parseStringToBI(minSudtCell, 8);
+  const minCkbCellCapacity = "63";
+  const minCkbCellShannons = parseStringToBI(minCkbCellCapacity, 8);
+  const minCkbCellCapacityWithFee = "64";
+  const minCkbCellShannonsWithFee = parseStringToBI(minCkbCellCapacityWithFee, 8);
+  const minSudtCellCapacity = "144";
+  const minSudtCellShannons = parseStringToBI(minSudtCellCapacity, 8);
 
   const ckbAmount = parseStringToBI(params.ckbValue || "0", 8);
   const ckbBalance = parseStringToBI(params.ckbBalance || "0");
@@ -139,10 +139,10 @@ export const getL1TransferInputError = (params: L1TransferInputParams): string |
     return `Enter Transfer Amount`;
   }
   if (params.ckbValue && ckbAmount.lt(minCkbCellShannons)) {
-    return `Minimum ${minCkbCell} CKB`;
+    return `Minimum ${minCkbCellCapacity} CKB`;
   }
-  if (ckbBalance.lt(ckbAmount.add(minCkbCellWithFeeShannons))) {
-    return `Balance Less Than ${minCkbCellWithFee} CKB`;
+  if (ckbBalance.lt(ckbAmount.add(minCkbCellShannonsWithFee))) {
+    return `Balance Less Than ${minCkbCellCapacityWithFee} CKB`;
   }
 
   const sudtAmount = parseStringToBI(params.sudtValue || "0", params.sudtDecimals);
@@ -155,8 +155,8 @@ export const getL1TransferInputError = (params: L1TransferInputParams): string |
     return `Insufficient ${params.sudtSymbol} Amount`;
   }
 
-  const minSudtExchange = BI.from(minCkbCellWithFee).add(minSudtCell);
-  const minSudtExchangeShannons = minCkbCellWithFeeShannons.add(minSudtCellShannons);
+  const minSudtExchange = BI.from(minCkbCellCapacityWithFee).add(minSudtCellCapacity);
+  const minSudtExchangeShannons = minCkbCellShannonsWithFee.add(minSudtCellShannons);
   if (params.sudtValue && sudtLeft.gt(0) && ckbBalance.lt(minSudtExchangeShannons)) {
     return `Balance Less Than ${minSudtExchange.toString()} CKB`;
   }

--- a/apps/godwoken-bridge/src/views/L1Transfer.tsx
+++ b/apps/godwoken-bridge/src/views/L1Transfer.tsx
@@ -1,0 +1,31 @@
+import { useLightGodwoken } from "../hooks/useLightGodwoken";
+import { Card, CardHeader, PageContent, Text } from "../style/common";
+import { WalletConnect } from "../components/WalletConnect";
+import RequestL1Transfer from "../components/L1Transfer/RequestL1Transfer";
+import L1TransferList from "../components/L1Transfer/L1TransferList";
+
+export default function L1Transfer() {
+  // light-godwoken client
+  const lightGodwoken = useLightGodwoken();
+
+  return (
+    <PageContent>
+      <Card className="content">
+        <WalletConnect />
+        <div style={{ opacity: lightGodwoken ? "1" : "0.5" }}>
+          <CardHeader>
+            <Text className="title">
+              <span>L1 Transfer</span>
+            </Text>
+          </CardHeader>
+          <RequestL1Transfer />
+        </div>
+      </Card>
+      {lightGodwoken && (
+        <Card className="content">
+          <L1TransferList />
+        </Card>
+      )}
+    </PageContent>
+  );
+}

--- a/packages/light-godwoken/src/__tests__/lightGodwoken.spec.ts
+++ b/packages/light-godwoken/src/__tests__/lightGodwoken.spec.ts
@@ -87,11 +87,13 @@ describe("test light godwoken generateDepositOutputCell", () => {
       .withArgs({
         lock: lightGodwokenV1.provider.getLayer1Lock(),
         type: sudtTypeWithoutArgs,
+        outputDataLenRange: ["0x10", "0x11"],
       })
       .returns(mockFreeSudtCollector)
       .withArgs({
         lock: lightGodwokenV1.provider.getLayer1Lock(),
         type: depositSudtTypeScript,
+        outputDataLenRange: ["0x10", "0x11"],
       })
       .returns(mockSudtCollector);
 

--- a/packages/light-godwoken/src/__tests__/lightGodwokenDeposit.spec.ts
+++ b/packages/light-godwoken/src/__tests__/lightGodwokenDeposit.spec.ts
@@ -53,11 +53,13 @@ const stubCellCollector = (options: StubOptions) => {
       .withArgs({
         lock: lightGodwokenInstance.provider.getLayer1Lock(),
         type: sudtTypeWithoutArgs,
+        outputDataLenRange: ["0x10", "0x11"],
       })
       .returns(mockFreeSudtCollector)
       .withArgs({
         lock: lightGodwokenInstance.provider.getLayer1Lock(),
         type: options.type,
+        outputDataLenRange: ["0x10", "0x11"],
       })
       .returns(mockSudtCollector);
   } else {
@@ -72,6 +74,7 @@ const stubCellCollector = (options: StubOptions) => {
       .withArgs({
         lock: lightGodwokenInstance.provider.getLayer1Lock(),
         type: sudtTypeWithoutArgs,
+        outputDataLenRange: ["0x10", "0x11"],
       })
       .returns(mockFreeSudtCollector);
   }

--- a/packages/light-godwoken/src/constants/error.ts
+++ b/packages/light-godwoken/src/constants/error.ts
@@ -36,4 +36,8 @@ export class DepositRejectedError extends LightGodwokenError<string> {}
 export class DepositCanceledError extends LightGodwokenError<string> {}
 export class WithdrawalTimeoutError extends LightGodwokenError<string> {}
 
+export class L1TransactionTimeoutError extends LightGodwokenError<string> {}
+export class L1TransactionRejectedError extends LightGodwokenError<string> {}
+export class L1TransactionNotExistError extends LightGodwokenError<string> {}
+
 export class TokenListNotFoundError extends LightGodwokenError<string> {}

--- a/packages/light-godwoken/src/lightGodwoken.ts
+++ b/packages/light-godwoken/src/lightGodwoken.ts
@@ -1173,6 +1173,9 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
         ...sudtTypeScript,
         args: "0x",
       },
+      // if sudt cell's data has more info than just amount (16 bytes), skip it
+      // because we don't know what the extension bytes contain
+      outputDataLenRange: ["0x10", "0x11"],
     });
 
     // type hash list of all sudt that user want to query

--- a/packages/light-godwoken/src/lightGodwoken.ts
+++ b/packages/light-godwoken/src/lightGodwoken.ts
@@ -347,6 +347,9 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
           config: this.getConfig().lumosConfig,
         }),
         type: payload.sudtType,
+        // if sudt cell's data has more info than just amount (16 bytes), skip it
+        // because we don't know what the extension bytes contain
+        outputDataLenRange: ["0x10", "0x11"],
       });
       for await (const cell of sudtCollector.collect()) {
         collectedCapatity = collectedCapatity.add(BI.from(cell.cell_output.capacity));
@@ -367,6 +370,9 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
           hash_type: this.getConfig().layer1Config.SCRIPTS.sudt.hash_type,
           args: "0x",
         },
+        // if sudt cell's data has more info than just amount (16 bytes), skip it
+        // because we don't know what the extension bytes contain
+        outputDataLenRange: ["0x10", "0x11"],
       });
       for await (const cell of freeCkbCollector.collect()) {
         const haveFreeCapacity = BI.from(SUDT_CELL_CAPACITY).lt(cell.cell_output.capacity);
@@ -899,6 +905,9 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
       const sudtCollector = this.provider.ckbIndexer.collector({
         lock: senderLock,
         type: payload.sudtType,
+        // if sudt cell's data has more info than just amount (16 bytes), skip it
+        // because we don't know what the extension bytes contain
+        outputDataLenRange: ["0x10", "0x11"],
       });
       for await (const cell of sudtCollector.collect()) {
         collectedCells.push(cell);
@@ -920,6 +929,9 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
           hash_type: config.layer1Config.SCRIPTS.sudt.hash_type,
           args: "0x",
         },
+        // if sudt cell's data has more info than just amount (16 bytes), skip it
+        // because we don't know what the extension bytes contain
+        outputDataLenRange: ["0x10", "0x11"],
       });
       for await (const cell of freeCkbCollector.collect()) {
         const hasFreeCkb = BI.from(cell.cell_output.capacity).gt(SUDT_CELL_CAPACITY);

--- a/packages/light-godwoken/src/lightGodwoken.ts
+++ b/packages/light-godwoken/src/lightGodwoken.ts
@@ -873,6 +873,25 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
     return txHash;
   }
 
+  /**
+   * The cell collecting & returning strategies in `l1-transfer` and `deposit` are different.
+   *
+   * ## Capacity collecting:
+   * In l1-transfer, the capacity collecting order: free sudt cell > ckb cell.
+   * In deposit, the capacity collecting order: ckb cell > free sudt cell.
+   *
+   * It means in l1-transfer, we will collect as more free sudt cells as possible,
+   * while in deposit we collect ckb cells first, and when we cannot find more ckb cells,
+   * we collect free sudt cells.
+   *
+   * ## Free sudt cells returning:
+   * In l1-transfer, the returning rule: merge same type of sudt cells into one.
+   * In deposit, the returning rule: we return how many cells as we collected.
+   *
+   * It means if we've collected 2 USDC cells,
+   * in l1-transfer we only return 1 USDC cell and the rest of capacity will be return in a ckb cell,
+   * while in deposit, we will return 2 USDC cells as we collected.
+   */
   async generateL1TransferTx(payload: L1TransferPayload): Promise<helpers.TransactionSkeletonType> {
     const config = this.getConfig();
 

--- a/packages/light-godwoken/src/lightGodwokenProvider.ts
+++ b/packages/light-godwoken/src/lightGodwokenProvider.ts
@@ -129,6 +129,9 @@ export default class DefaultLightGodwokenProvider implements LightGodwokenProvid
         hash_type: this.getConfig().layer1Config.SCRIPTS.sudt.hash_type,
         args: "0x",
       },
+      // if sudt cell's data has more info than just amount (16 bytes), skip it
+      // because we don't know what the extension bytes contain
+      outputDataLenRange: ["0x10", "0x11"],
     });
     for await (const cell of freeCkbCollector.collect()) {
       ckbBalance = ckbBalance.add(cell.cell_output.capacity).sub(SUDT_CELL_CAPACITY);

--- a/packages/light-godwoken/src/lightGodwokenType.ts
+++ b/packages/light-godwoken/src/lightGodwokenType.ts
@@ -2,6 +2,7 @@ import { Address, Cell, Hash, HexNumber, Transaction, helpers, Script, BI, HexSt
 import { GodwokenNetwork, GodwokenVersion, LightGodwokenConfig } from "./config";
 import { GodwokenScannerDataTypes } from "./godwokenScanner";
 import EventEmitter from "events";
+import { TransactionWithStatus } from "@ckb-lumos/base";
 
 export interface GetL2CkbBalancePayload {
   l2Address?: string;
@@ -69,6 +70,12 @@ interface DepositListener {
   (event: "fail", listener: (e: Error) => void): void;
 }
 
+interface L1TransactionListener {
+  (event: "pending", listener: (txHash: Hash) => void): void;
+  (event: "success", listener: (txHash: Hash) => void): void;
+  (event: "fail", listener: (e: Error) => void): void;
+}
+
 export interface WithdrawalEventEmitter {
   on: WithdrawListener;
   removeAllListeners(event?: string | symbol): this;
@@ -79,6 +86,12 @@ export interface DepositEventEmitter {
   on: DepositListener;
   removeAllListeners(event?: string | symbol): this;
   emit: (event: "sent" | "pending" | "success" | "fail", payload: any) => void;
+}
+
+export interface L1TransactionEventEmitter {
+  on: L1TransactionListener;
+  removeAllListeners(event?: string | symbol): this;
+  emit: (event: "pending" | "success" | "fail", payload: any) => void;
 }
 
 export interface BaseWithdrawalEventEmitterPayload {
@@ -158,6 +171,8 @@ export interface LightGodwokenProvider {
 
   // now only supported omni lock, the other lock type will be supported later
   sendL1Transaction: (tx: Transaction) => Promise<Hash>;
+
+  waitForL1Transaction: (txHash: Hash) => Promise<TransactionWithStatus>;
 }
 
 export type DepositRequest = {
@@ -175,6 +190,12 @@ export type DepositResult = {
   sudt?: SUDT;
   status: "pending" | "success" | "failed";
 };
+
+export interface L1TransferPayload {
+  toAddress: Address;
+  amount: HexNumber;
+  sudtType?: Script;
+}
 
 export interface LightGodwokenBase {
   provider: LightGodwokenProvider;
@@ -221,6 +242,10 @@ export interface LightGodwokenBase {
   subscribPendingDepositTransactions: (payload: PendingDepositTransaction[]) => DepositEventEmitter;
 
   withdrawWithEvent: (payload: WithdrawalEventEmitterPayload) => WithdrawalEventEmitter;
+
+  l1Transfer: (payload: L1TransferPayload, eventEmitter?: EventEmitter) => Promise<Hash>;
+
+  subscribePendingL1Transactions: (txs: Hash[]) => L1TransactionEventEmitter;
 
   getL2CkbBalance: (payload?: GetL2CkbBalancePayload) => Promise<HexNumber>;
 

--- a/packages/light-godwoken/src/utils/async.ts
+++ b/packages/light-godwoken/src/utils/async.ts
@@ -1,0 +1,25 @@
+export function waitFor(milliseconds: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+export async function retryIfFailed<T = any>(action: () => T, maxRetry = 3, interval = 1000) {
+  let retries = 0;
+
+  async function process(): Promise<T> {
+    try {
+      return await action();
+    } catch (error) {
+      if (retries < maxRetry) {
+        await waitFor(interval);
+        retries += 1;
+        return await process();
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  return await process();
+}


### PR DESCRIPTION
### Changes
- Feat: L1 transfer relevant functions in light-godwoken
- Feat: L1 transfer route in godwoken-bridge
- Refactor: refactor Header/Body in godwoken-bridge for better adaptability

### Related issues
- https://github.com/godwokenrises/light-godwoken/issues/189

### Details

1. **Different capacity collection strategy**
When depositing, light-godwoken mainly collect capacity from pure CKB cells, and when pure CKB cells are not enough, light-godwoken will then collect capacity from sUDT cells with extra capacity (capacity > 144 CKB).
When l1-transferring, light-godwoken will preferentially collect capacity from sUDT cells with extra capacity (capacity > 144 CKB), and when that is not enough, light-godwoken will then collect capacity from pure CKB cells.

2. **Different exchange strategy**
When depositing, light-godwoken sometime collects capacity from sUDT cells with extra capacity, and will exchange the same amount of sUST cells as collected in transaction outputs filed. 
For example if there are two sUDT cells with capacity of 200 CKB has been collected, light-godwoken will then put two sUDT cells with capacity of 144 CKB in the transaction outputs filed. The extra 112 CKB will be used in the transaction, and excess capacity will be return in transaction outputs field, as a pure CKB cell.
When l1-transferring, the only difference is that when exchanging sUDT cells, the same type of sUDT cells will be merged. For example if light-godwoken has collected two ETH cells (each worth of 1 ETH) and one WBTC cell, in transaction outputs field there will be one ETH cell (worth of 2 ETH) and one WBTC cell. The two ETH cells are of the same type, so they are merged into one cell.

3. **Local history**
It would be hard if we try to tell which L1 transfer record is what we wanted, and which is not.
So currently L1 transfer history is only stored locally, and only the latest 15 records are retained.