### PR TITLE
[TESTING] Testing for unlock legacy withdrawal cells feature

### DIFF
--- a/packages/light-godwoken/src/LightGodwokenV0.ts
+++ b/packages/light-godwoken/src/LightGodwokenV0.ts
@@ -417,7 +417,7 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
 
     const withdrawalRequestExtra = {
       request: withdrawalRequest,
-      owner_lock: ownerLock,
+      // owner_lock: ownerLock,
       withdraw_to_v1: withdrawToV1 ? 1 : 0,
     };
 


### PR DESCRIPTION
This is a temporary PR for testing only, close it after the testing completed.

The feature can only be tested on `mainnet_v0`, so please use the Vercel mainnet preview link to test it.

The PR is based on `feat-v0-unlock` branch, changes:
- Remove `owner_lock` from withdrawal_request v0, so after the withdrawal cell is finalized, user need to manually unlock it on godwoken-bridge
