### PR TITLE
Chore: bump v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 0.2.0 (2022-10-09)
 
+# 0.3.0 (2022-11-01)
 
 ### Bug Fixes
+* Fix ckb validation in withdrawal_v1 route ([#195](https://github.com/godwokenrises/light-godwoken/issues/195))
 
+### Features
+* Unlock legacy withdrawal cells feature ([#200](https://github.com/godwokenrises/light-godwoken/pull/200))
+* L1-transfer feature ([#210](https://github.com/godwokenrises/light-godwoken/pull/210))
+* Replace testnet_v1 tokens with Goerli tokens ([#208](https://github.com/godwokenrises/light-godwoken/pull/208))
+* Add token logo for "COOP" ([#212](https://github.com/godwokenrises/light-godwoken/pull/212))
+
+
+# 0.2.0 (2022-10-09)
+
+### Bug Fixes
 * Token logo for "YOK" and "TAI" ([#178](https://github.com/nervosnetwork/light-godwoken/issues/178))
 * Testnet_v0 is officially deprecated ([#184](https://github.com/nervosnetwork/light-godwoken/issues/184))
 * Withdrawal history list might need pagination ([#190](https://github.com/nervosnetwork/light-godwoken/issues/190))
 * Deposit/Withdraw canceling signature in metamask prompts unknown error ([#192](https://github.com/nervosnetwork/light-godwoken/issues/192))
 
-
 ### Features
-
-* replace LightGodwokenConfigMap with LightGodwokenConfig ([f89547d](https://github.com/nervosnetwork/light-godwoken/commits/f89547df037cd6eebe04330ec23edb36db44a47c))
-* make predefined tokens customizable ([ff4ec424](https://github.com/nervosnetwork/light-godwoken/commits/ff4ec4246d73611a079f7c899453089c8fe54ae7))
-* l1-deposit-address and display QRCode for addresses ([eea43ae](https://github.com/nervosnetwork/light-godwoken/commit/eea43aef0fd6a725a90978ceeb4d9d962e4adfcd))
+* Replace LightGodwokenConfigMap with LightGodwokenConfig ([f89547d](https://github.com/nervosnetwork/light-godwoken/commits/f89547df037cd6eebe04330ec23edb36db44a47c))
+* Make predefined tokens customizable ([ff4ec424](https://github.com/nervosnetwork/light-godwoken/commits/ff4ec4246d73611a079f7c899453089c8fe54ae7))
+* L1-deposit-address and display QRCode for addresses ([eea43ae](https://github.com/nervosnetwork/light-godwoken/commit/eea43aef0fd6a725a90978ceeb4d9d962e4adfcd))

--- a/apps/godwoken-bridge/CHANGELOG.md
+++ b/apps/godwoken-bridge/CHANGELOG.md
@@ -3,16 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 0.2.0 (2022-10-09)
 
+# 0.3.0 (2022-11-01)
 
 ### Bug Fixes
+* Fix ckb validation in withdrawal_v1 route ([#195](https://github.com/godwokenrises/light-godwoken/issues/195))
 
+### Features
+* Unlock legacy withdrawal cells feature ([#200](https://github.com/godwokenrises/light-godwoken/pull/200))
+* L1-transfer feature ([#210](https://github.com/godwokenrises/light-godwoken/pull/210))
+
+
+# 0.2.0 (2022-10-09)
+
+### Bug Fixes
 * Testnet_v0 is officially deprecated ([#184](https://github.com/nervosnetwork/light-godwoken/issues/184))
 * Withdrawal history list might need pagination ([#190](https://github.com/nervosnetwork/light-godwoken/issues/190))
 * Deposit/Withdraw canceling signature in metamask prompts unknown error ([#192](https://github.com/nervosnetwork/light-godwoken/issues/192))
 
-
 ### Features
-
-* l1-deposit-address and display QRCode for addresses ([eea43ae](https://github.com/nervosnetwork/light-godwoken/commit/eea43aef0fd6a725a90978ceeb4d9d962e4adfcd))
+* L1-deposit-address and display QRCode for addresses ([eea43ae](https://github.com/nervosnetwork/light-godwoken/commit/eea43aef0fd6a725a90978ceeb4d9d962e4adfcd))

--- a/apps/godwoken-bridge/package.json
+++ b/apps/godwoken-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godwoken-bridge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "start": "react-scripts start",
@@ -52,7 +52,7 @@
     "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.28.0",
     "events": "^3.3.0",
-    "light-godwoken": "^0.2.0",
+    "light-godwoken": "^0.3.0",
     "numeral": "^2.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packages": [
     "packages/**",
     "apps/**",

--- a/packages/light-godwoken/CHANGELOG.md
+++ b/packages/light-godwoken/CHANGELOG.md
@@ -3,14 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## 0.2.0 (2022-10-09)
 
+# 0.3.0 (2022-11-01)
+
+### Features
+* Unlock legacy withdrawal cells feature ([#200](https://github.com/godwokenrises/light-godwoken/pull/200))
+* L1-transfer feature ([#210](https://github.com/godwokenrises/light-godwoken/pull/210))
+* Replace testnet_v1 tokens with Goerli tokens ([#208](https://github.com/godwokenrises/light-godwoken/pull/208))
+* Add token logo for "COOP" ([#212](https://github.com/godwokenrises/light-godwoken/pull/212))
+
+
+# 0.2.0 (2022-10-09)
 
 ### Bug Fixes
-
 * Token logo for "YOK" and "TAI" ([#178](https://github.com/nervosnetwork/light-godwoken/issues/178))
 
 ### Features
-
-* replace LightGodwokenConfigMap with LightGodwokenConfig ([f89547d](https://github.com/nervosnetwork/light-godwoken/commits/f89547df037cd6eebe04330ec23edb36db44a47c))
-* make predefined tokens customizable ([ff4ec424](https://github.com/nervosnetwork/light-godwoken/commits/ff4ec4246d73611a079f7c899453089c8fe54ae7))
+* Replace LightGodwokenConfigMap with LightGodwokenConfig ([f89547d](https://github.com/nervosnetwork/light-godwoken/commits/f89547df037cd6eebe04330ec23edb36db44a47c))
+* Make predefined tokens customizable ([ff4ec424](https://github.com/nervosnetwork/light-godwoken/commits/ff4ec4246d73611a079f7c899453089c8fe54ae7))

--- a/packages/light-godwoken/package.json
+++ b/packages/light-godwoken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-godwoken",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Publishing light-godwoken v0.3.0 with the latest version of changelog.