### PR TITLE
Feat: add project relevant links

### DIFF
--- a/apps/godwoken-bridge/src/components/Container/Empty.tsx
+++ b/apps/godwoken-bridge/src/components/Container/Empty.tsx
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import { PropsWithChildren } from "react";
+import { Icon } from "@ricons/utils";
+import { InboxFilled } from "@ricons/material";
+
+const EmptyStyleWrapper = styled.div`
+  padding-top: 16px;
+  padding-bottom: 4px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  .icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 70px;
+    height: 70px;
+    font-size: 40px;
+    border-radius: 70px;
+    color: #548154;
+    background-color: #f3f3f3;
+  }
+
+  .text {
+    color: #666666;
+    margin-top: 6px;
+    user-select: none;
+  }
+`;
+
+export function Empty(props: PropsWithChildren<{}>) {
+  return (
+    <EmptyStyleWrapper>
+      <div className="icon">
+        <Icon>
+          <InboxFilled />
+        </Icon>
+      </div>
+      {props.children && <div className="text">{props.children}</div>}
+    </EmptyStyleWrapper>
+  );
+}

--- a/apps/godwoken-bridge/src/components/Deposit/List.tsx
+++ b/apps/godwoken-bridge/src/components/Deposit/List.tsx
@@ -11,6 +11,7 @@ import { Placeholder } from "../Placeholder";
 import { LinkList, Tab } from "../../style/common";
 import { useLightGodwoken } from "../../hooks/useLightGodwoken";
 import { DepositHistoryType } from "../../hooks/useDepositTxHistory";
+import { Empty } from "../Container/Empty";
 
 const DepositListDiv = styled.div`
   border-bottom-left-radius: 24px;
@@ -113,7 +114,7 @@ export const DepositList: React.FC<DepositListParams> = ({ depositList, isLoadin
       </LinkList>
       {isPending && (
         <div className="list pending-list">
-          {pendingList.length === 0 && "There is no pending deposit request here"}
+          {pendingList.length === 0 && <Empty>No pending deposits</Empty>}
           {pendingList.map((deposit, index) => (
             <DepositItem {...deposit} key={index}></DepositItem>
           ))}
@@ -121,7 +122,7 @@ export const DepositList: React.FC<DepositListParams> = ({ depositList, isLoadin
       )}
       {isCompleted && (
         <div ref={listRef} className="list completed-list">
-          {!completedList.length && !depositHistoryList.length && "There is no completed deposit request here"}
+          {!completedList.length && !depositHistoryList.length && <Empty>No completed deposits</Empty>}
           {completedList.map((deposit, index) => (
             <DepositItem {...deposit} key={index}></DepositItem>
           ))}

--- a/apps/godwoken-bridge/src/components/L1Transfer/L1TransferList.tsx
+++ b/apps/godwoken-bridge/src/components/L1Transfer/L1TransferList.tsx
@@ -8,6 +8,7 @@ import { useL1TxHistory } from "../../hooks/useL1TxHistory";
 import { Placeholder } from "../Placeholder";
 import L1TransferItem from "./L1TransferItem";
 import { L1TransactionEventEmitter, L1TransactionRejectedError, LightGodwokenError } from "light-godwoken";
+import { Empty } from "../Container/Empty";
 
 const L1TransferListStyleWrapper = styled.div`
   border-bottom-left-radius: 24px;
@@ -102,7 +103,7 @@ export default function L1TransferList() {
       </LinkList>
       {isPending && (
         <div className="list pending-list">
-          {pendingList.length === 0 && "There is no pending transfers here"}
+          {pendingList.length === 0 && <Empty>No pending transfers</Empty>}
           {pendingList.map((props, index) => (
             <L1TransferItem {...props} key={index} />
           ))}
@@ -110,7 +111,7 @@ export default function L1TransferList() {
       )}
       {isCompleted && (
         <div className="list completed-list">
-          {completedList.length === 0 && "There is no completed transfers here"}
+          {completedList.length === 0 && <Empty>No completed transfers</Empty>}
           {completedList.map((props, index) => (
             <L1TransferItem {...props} key={index} />
           ))}

--- a/apps/godwoken-bridge/src/components/Layout/PageFooter.tsx
+++ b/apps/godwoken-bridge/src/components/Layout/PageFooter.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ReactComponent as Hamburger } from "../../assets/hamburger.svg";
 
 import styled from "styled-components";
 import { Popover } from "antd";
 import { PopoverMenu } from "../PopoverMenu";
 import { VersionSelect } from "../VersionSelect";
-import { isMainnet } from "../../utils/environment";
+
 const StyledPage = styled.div`
   position: fixed;
   bottom: 0;
@@ -23,38 +23,33 @@ const StyledPage = styled.div`
 `;
 
 export default function PageFooter() {
+  const footerRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLInputElement>;
   const [popoverVisible, setPopoverVisible] = useState(false);
 
   useEffect(() => {
     document.addEventListener("click", (e) => {
       const target = document.querySelector(".hamburger-menu-bottom");
       if (!(e.target && e.target instanceof Element && (e.target === target || target?.contains(e.target)))) {
-        closePopoverMenu();
+        setPopoverVisible(false);
       }
     });
   });
 
-  const openPopoverMenu = () => {
-    setPopoverVisible(true);
-  };
-
-  const closePopoverMenu = () => {
-    setPopoverVisible(false);
-  };
   return (
-    <StyledPage>
-      <VersionSelect />
-      {!isMainnet && (
-        <Popover
-          trigger="click"
-          placement="bottomLeft"
-          overlayClassName="popover-menu"
-          visible={popoverVisible}
-          content={() => <PopoverMenu handleClick={closePopoverMenu} />}
-        >
-          <Hamburger className="hamburger-menu-bottom" onClick={openPopoverMenu} />
-        </Popover>
-      )}
+    <StyledPage ref={footerRef}>
+      <VersionSelect placement="topRight" />
+      <Popover
+        autoAdjustOverflow
+        destroyTooltipOnHide
+        trigger="focus"
+        placement="topRight"
+        overlayClassName="popover-menu"
+        visible={popoverVisible}
+        getPopupContainer={() => footerRef.current}
+        content={<PopoverMenu handleClick={() => setPopoverVisible(false)} />}
+      >
+        <Hamburger className="hamburger-menu-bottom" onClick={() => setPopoverVisible(true)} />
+      </Popover>
     </StyledPage>
   );
 }

--- a/apps/godwoken-bridge/src/components/Layout/PageHeader.tsx
+++ b/apps/godwoken-bridge/src/components/Layout/PageHeader.tsx
@@ -6,7 +6,6 @@ import styled from "styled-components";
 import { Popover } from "antd";
 import { PopoverMenu } from "../PopoverMenu";
 import { VersionSelect } from "../VersionSelect";
-import { isMainnet } from "../../utils/environment";
 import { matchPath, useLocation, useNavigate, useParams } from "react-router-dom";
 
 const StyledPage = styled.div`
@@ -139,17 +138,14 @@ export default function PageHeader() {
       </div>
       <div className="right-side">
         <VersionSelect />
-        {!isMainnet && (
-          <Popover
-            trigger="click"
-            placement="bottomLeft"
-            overlayClassName="popover-menu"
-            visible={popoverVisible}
-            content={() => <PopoverMenu handleClick={() => setPopoverVisible(false)} />}
-          >
-            <Hamburger className="hamburger-menu" onClick={() => setPopoverVisible(true)} />
-          </Popover>
-        )}
+        <Popover
+          trigger="hover"
+          placement="bottomLeft"
+          overlayClassName="popover-menu"
+          content={() => <PopoverMenu handleClick={() => setPopoverVisible(false)} />}
+        >
+          <Hamburger className="hamburger-menu" />
+        </Popover>
       </div>
     </StyledPage>
   );

--- a/apps/godwoken-bridge/src/components/PopoverMenu/index.tsx
+++ b/apps/godwoken-bridge/src/components/PopoverMenu/index.tsx
@@ -1,42 +1,92 @@
-import React from "react";
+import React, { PropsWithChildren, ReactNode } from "react";
 import styled from "styled-components";
 import { COLOR } from "../../style/variables";
 import { ClaimSudt } from "../ClaimSudt";
+import { isMainnet } from "../../utils/environment";
+import { OpenInNewRound } from "@ricons/material";
+import { Icon } from "@ricons/utils";
 
-const StyleWrapper = styled.div`
+const PopoverMenuStyleWrapper = styled.div`
   display: flex;
   flex-direction: column;
+
   > a,
   > div {
-    color: ${COLOR.primary};
-    text-decoration: none;
-    cursor: pointer;
-    height: 33px;
+    margin: 4px 0;
     padding: 0 10px;
-    border-radius: 8px;
-    margin: 4px 0px;
-    text-align: center;
+    min-width: 220px;
+    height: 33px;
     line-height: 33px;
+    color: ${COLOR.secondary};
+    text-decoration: none;
+    border-radius: 8px;
     font-size: 14px;
-    font-weight: bold;
+    font-weight: 600;
+    cursor: pointer;
+
     &:hover {
-      background: rgba(0, 0, 0, 0.1);
+      background: #f3f3f3;
       color: ${COLOR.primary};
+    }
+    &:active {
+      background: #ececec;
     }
   }
 `;
-type Props = {
+
+const PopoverMenuLinkStyleWrapper = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+
+  > .icon {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 4px;
+    color: ${COLOR.label};
+  }
+`;
+
+export interface PopoverMenuProps {
   handleClick: () => void;
-};
-export const PopoverMenu: React.FC<Props> = ({ handleClick }) => {
+}
+
+export function PopoverMenu({ handleClick }: PopoverMenuProps) {
   return (
-    <StyleWrapper>
-      <div className="claim-sudt-container" onClick={handleClick}>
-        <ClaimSudt />
-      </div>
-      <a href="https://faucet.nervos.org" target="_blank" rel="noreferrer" onClick={handleClick}>
-        CKB Testnet Faucet
-      </a>
-    </StyleWrapper>
+    <PopoverMenuStyleWrapper>
+      {!isMainnet && (
+        <div className="claim-sudt-container" onClick={handleClick}>
+          <ClaimSudt />
+        </div>
+      )}
+      <PopoverMenuLink href="https://faucet.nervos.org" onClick={handleClick}>
+        Claim CKB Faucet on L1
+      </PopoverMenuLink>
+      <PopoverMenuLink href="https://docs.godwoken.io" onClick={handleClick}>
+        Godwoken Docs
+      </PopoverMenuLink>
+      <PopoverMenuLink href="https://github.com/godwokenrises/light-godwoken" onClick={handleClick}>
+        GitHub
+      </PopoverMenuLink>
+    </PopoverMenuStyleWrapper>
   );
-};
+}
+
+interface PopoverMenuLinkProps {
+  href: string;
+  children: ReactNode;
+  onClick?: () => void;
+}
+
+export function PopoverMenuLink(props: PopoverMenuLinkProps) {
+  return (
+    <PopoverMenuLinkStyleWrapper target="_blank" rel="noreferrer" href={props.href} onClick={props.onClick}>
+      {props.children}
+      <div className="icon">
+        <Icon>
+          <OpenInNewRound />
+        </Icon>
+      </div>
+    </PopoverMenuLinkStyleWrapper>
+  );
+}

--- a/apps/godwoken-bridge/src/components/VersionSelect/index.tsx
+++ b/apps/godwoken-bridge/src/components/VersionSelect/index.tsx
@@ -1,11 +1,15 @@
-import React from "react";
 import { Select } from "antd";
+import { Placement } from "rc-select/lib/generate";
 import { useParams, useNavigate } from "react-router-dom";
 import { availableVersions } from "../../utils/environment";
 
 const { Option } = Select;
 
-export const VersionSelect: React.FC = () => {
+export interface VersionSelectProps {
+  placement?: Placement;
+}
+
+export function VersionSelect(props: VersionSelectProps) {
   const params = useParams();
   const navigate = useNavigate();
   function handleChange(value: string) {
@@ -15,6 +19,8 @@ export const VersionSelect: React.FC = () => {
   return (
     <Select
       style={{ width: 160, marginLeft: "10px", marginRight: "10px" }}
+      getPopupContainer={(node) => node}
+      placement={props.placement}
       value={params.version}
       onChange={handleChange}
     >
@@ -25,4 +31,4 @@ export const VersionSelect: React.FC = () => {
       ))}
     </Select>
   );
-};
+}

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV0.tsx
@@ -14,6 +14,7 @@ import WithdrawalRequestCard from "./WithdrawalItemV0";
 import { createLightGodwokenV1 } from "../../utils/lightGodwoken";
 import { useGodwokenVersion } from "../../hooks/useGodwokenVersion";
 import { useL1UnlockHistory } from "../../hooks/useL1UnlockHistory";
+import { Empty } from "../Container/Empty";
 
 const WithdrawalListDiv = styled.div`
   border-bottom-left-radius: 24px;
@@ -149,7 +150,7 @@ export const WithdrawalList: React.FC = () => {
       </LinkList>
       {isPending && (
         <div className="list pending-list">
-          {pendingList.length === 0 && "There is no pending withdrawal request here"}
+          {pendingList.length === 0 && <Empty>No pending withdrawals</Empty>}
           {pendingList.map((withdraw, index) => (
             <WithdrawalRequestCard now={now} {...withdraw} key={index} />
           ))}
@@ -157,7 +158,7 @@ export const WithdrawalList: React.FC = () => {
       )}
       {isCompleted && (
         <div className="list pending-list">
-          {completedList.length === 0 && "There is no completed withdrawal request here"}
+          {completedList.length === 0 && <Empty>No completed withdrawals</Empty>}
           {completedList.map((withdraw: any, index: number) => (
             <WithdrawalRequestCard now={now} {...withdraw} key={index} />
           ))}

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -11,6 +11,7 @@ import { useLightGodwoken } from "../../hooks/useLightGodwoken";
 import { Placeholder } from "../Placeholder";
 import { L1TxHistoryInterface } from "../../hooks/useL1TxHistory";
 import WithdrawalRequestCard from "./WithdrawalItemV1";
+import { Empty } from "../Container/Empty";
 
 const WithdrawalListDiv = styled.div`
   border-bottom-left-radius: 24px;
@@ -108,7 +109,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
       </LinkList>
       {isPending && (
         <div className="list pending-list">
-          {pendingList.length + displayLocalTxHistory.length === 0 && "There is no pending withdrawal request here"}
+          {pendingList.length + displayLocalTxHistory.length === 0 && <Empty>No pending withdrawals</Empty>}
           {displayLocalTxHistory.map((withdraw, index) => (
             <WithdrawalRequestCard {...withdraw} key={index}></WithdrawalRequestCard>
           ))}
@@ -119,7 +120,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
       )}
       {isCompleted && (
         <div ref={listRef} className="list pending-list">
-          {completedList.length === 0 && "There is no completed withdrawal request here"}
+          {completedList.length === 0 && <Empty>No completed withdrawals</Empty>}
           {completedList.map((withdraw, index) => (
             <WithdrawalRequestCard {...withdraw} key={index}></WithdrawalRequestCard>
           ))}

--- a/apps/godwoken-bridge/src/index.css
+++ b/apps/godwoken-bridge/src/index.css
@@ -33,7 +33,10 @@ code {
 
 /* ant-popover-reset */
 .ant-popover.popover-menu {
-  padding-top: 30px;
+  padding-top: 25px;
+}
+.ant-popover.popover-menu .ant-popover-inner {
+  border-radius: 10px 0 10px 10px;
 }
 .ant-popover.popover-menu .ant-popover-inner-content {
   padding: 8px;
@@ -44,6 +47,10 @@ code {
 @media (max-width: 1024px) {
   .ant-popover.popover-menu {
     padding-bottom: 13px;
+  }
+  .ant-popover.popover-menu .ant-popover-inner {
+    border-top-right-radius: 10px;
+    border-bottom-right-radius: 0;
   }
 }
 

--- a/apps/godwoken-bridge/src/views/Deposit.tsx
+++ b/apps/godwoken-bridge/src/views/Deposit.tsx
@@ -11,6 +11,7 @@ import { useL1CKBBalance } from "../hooks/useL1CKBBalance";
 import { useL2CKBBalance } from "../hooks/useL2CKBBalance";
 import { DepositEventEmitter, SUDT, UniversalToken } from "light-godwoken";
 import {
+  PageContent,
   ConfirmModal,
   Card,
   PlusIconContainer,
@@ -252,7 +253,7 @@ export default function Deposit() {
   };
 
   return (
-    <>
+    <PageContent>
       <Card>
         <WalletConnect></WalletConnect>
         <div style={{ opacity: lightGodwoken ? "1" : "0.5" }}>
@@ -335,6 +336,6 @@ export default function Deposit() {
           <Tips>Waiting for User Confirmation</Tips>
         </ModalContent>
       </ConfirmModal>
-    </>
+    </PageContent>
   );
 }


### PR DESCRIPTION
### Changes
- Add godwoken-docs's link and light-godwoken's repo link to godwoken-bridge
- Fix some overflow issues in deopsit page, header and footer
- Add Empty component to beautify all empty lists

### Relevant issues
- #202

### Details

- **New added links** 
  Added links to [light-godwoken](https://github.com/godwokenrises/light-godwoken) and [godwoken-doc](https://doc.godwoken.io), and beautified the popover list. 
  One more fix is originally the popover component won't stick on the screen when we scroll the page, and now it just stick at the page, will not move with the page body when scrolling.
  ![image](https://user-images.githubusercontent.com/44739165/200262138-7aaeda9d-17bc-4a75-b133-b5ef40aebaec.png)

- **Empty lists**
  Added a new component `Empty`, now when a list is empty, it displays this component instead.
  ![image](https://user-images.githubusercontent.com/44739165/200263222-c28842f4-d114-4633-b5f6-1ab6738175e3.png)

