### PR TITLE
Feat: add `waitForCompletion` to deposit/withdraw

### DIFF
--- a/packages/light-godwoken/src/LightGodwokenV0.ts
+++ b/packages/light-godwoken/src/LightGodwokenV0.ts
@@ -35,7 +35,7 @@ import {
 import { CKB_SUDT_ID } from "./tokens";
 import { AbiItems } from "@polyjuice-provider/base";
 import { SUDT_ERC20_PROXY_ABI } from "./constants/sudtErc20ProxyAbi";
-import { GodwokenClient } from "./godwoken/godwokenV0";
+import { GodwokenV0 } from "./godwoken";
 import LightGodwokenProvider from "./lightGodwokenProvider";
 import { RawWithdrawal, RawWithdrawalCodec, V0DepositLockArgs, WithdrawalRequestExtraCodec } from "./schemas/codecV0";
 import { debug } from "./debug";
@@ -66,7 +66,7 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
 
   constructor(provider: LightGodwokenProvider) {
     super(provider);
-    this.godwokenClient = new GodwokenClient(provider.getConfig().layer2Config.GW_POLYJUICE_RPC_URL);
+    this.godwokenClient = new GodwokenV0(provider.getConfig().layer2Config.GW_POLYJUICE_RPC_URL);
     this.godwokenScannerClient = new GodwokenScanner(provider.getConfig().layer2Config.SCANNER_API);
   }
 

--- a/packages/light-godwoken/src/LightGodwokenV0.ts
+++ b/packages/light-godwoken/src/LightGodwokenV0.ts
@@ -361,13 +361,16 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
     return result;
   }
 
-  withdrawWithEvent(payload: WithdrawalEventEmitterPayload): WithdrawalEventEmitter {
+  withdrawWithEvent(payload: WithdrawalEventEmitterPayload, waitForCompletion?: boolean): WithdrawalEventEmitter {
     const eventEmitter = new EventEmitter();
-    this.withdraw(eventEmitter, payload);
+    this.withdraw(eventEmitter, payload, false, waitForCompletion);
     return eventEmitter;
   }
 
-  withdrawToV1WithEvent(payload: WithdrawalToV1EventEmitterPayload): WithdrawalEventEmitter {
+  withdrawToV1WithEvent(
+    payload: WithdrawalToV1EventEmitterPayload,
+    waitForCompletion?: boolean,
+  ): WithdrawalEventEmitter {
     const eventEmitter = new EventEmitter();
     const v1DepositLock = payload.lightGodwoken.generateDepositLock();
     const withdrawalAddress = helpers.encodeToAddress(v1DepositLock, {
@@ -381,6 +384,7 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
         withdrawal_address: withdrawalAddress,
       },
       true,
+      waitForCompletion,
     );
     return eventEmitter;
   }
@@ -389,6 +393,7 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
     eventEmitter: EventEmitter,
     payload: WithdrawalEventEmitterPayload,
     withdrawToV1 = false,
+    waitForCompletion = true,
   ): Promise<void> {
     const { lumosConfig, layer2Config } = this.provider.getConfig();
     const ownerLock = helpers.parseAddress(payload.withdrawal_address || this.provider.l1Address, {
@@ -436,7 +441,9 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
     if (txHash) {
       eventEmitter.emit("sent", txHash);
       debug("withdrawal request result:", txHash);
-      this.waitForWithdrawalToComplete(txHash, eventEmitter);
+      if (waitForCompletion) {
+        this.waitForWithdrawalToComplete(txHash, eventEmitter);
+      }
     }
   }
 

--- a/packages/light-godwoken/src/LightGodwokenV1.ts
+++ b/packages/light-godwoken/src/LightGodwokenV1.ts
@@ -284,9 +284,9 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
     return this.godwokenClient.getWithdrawal(txHash);
   }
 
-  withdrawWithEvent(payload: WithdrawalEventEmitterPayload): WithdrawalEventEmitter {
+  withdrawWithEvent(payload: WithdrawalEventEmitterPayload, waitForCompletion?: boolean): WithdrawalEventEmitter {
     const eventEmitter = new EventEmitter();
-    this.withdraw(eventEmitter, payload);
+    this.withdraw(eventEmitter, payload, waitForCompletion);
     return eventEmitter;
   }
 
@@ -294,7 +294,11 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
     return this.godwokenClient.getChainId();
   }
 
-  async withdraw(eventEmitter: EventEmitter, payload: WithdrawalEventEmitterPayload): Promise<void> {
+  async withdraw(
+    eventEmitter: EventEmitter,
+    payload: WithdrawalEventEmitterPayload,
+    waitForCompletion = true,
+  ): Promise<void> {
     const rawWithdrawalRequest = await this.generateRawWithdrawalRequest(eventEmitter, payload);
     const typedMsg = this.generateTypedMsg(rawWithdrawalRequest);
 
@@ -330,7 +334,9 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
     if (txHash) {
       eventEmitter.emit("sent", txHash);
       debug("withdrawal request result:", txHash, eventEmitter);
-      this.waitForWithdrawalToComplete(txHash, eventEmitter);
+      if (waitForCompletion) {
+        this.waitForWithdrawalToComplete(txHash, eventEmitter);
+      }
     }
   }
 

--- a/packages/light-godwoken/src/LightGodwokenV1.ts
+++ b/packages/light-godwoken/src/LightGodwokenV1.ts
@@ -1,7 +1,7 @@
 import { GodwokenScanner } from "./godwokenScanner";
 import { BI, Cell, Hash, HashType, helpers, HexNumber, HexString, Script, toolkit, utils } from "@ckb-lumos/lumos";
 import EventEmitter from "events";
-import { Godwoken as GodwokenV1 } from "./godwoken/godwokenV1";
+import { GodwokenV1 } from "./godwoken";
 import {
   DepositResult,
   GetErc20Balances,

--- a/packages/light-godwoken/src/godwoken/godwokenV0.ts
+++ b/packages/light-godwoken/src/godwoken/godwokenV0.ts
@@ -11,8 +11,8 @@ interface LastL2BlockCommittedInfo {
 /**
  * Godwoken RPC client
  */
-export class GodwokenClient {
-  private rpc: RPC;
+export class GodwokenV0 {
+  private readonly rpc: RPC;
 
   constructor(url: string) {
     this.rpc = new RPC(url);
@@ -20,8 +20,7 @@ export class GodwokenClient {
 
   private async rpcCall(method_name: string, ...args: any[]): Promise<any> {
     const name = "gw_" + method_name;
-    const result = await this.rpc[name](...args);
-    return result;
+    return this.rpc[name](...args);
   }
 
   /**

--- a/packages/light-godwoken/src/godwoken/godwokenV1.ts
+++ b/packages/light-godwoken/src/godwoken/godwokenV1.ts
@@ -4,6 +4,8 @@
  */
 import { RPC } from "ckb-js-toolkit";
 import { Hash, Hexadecimal, HexNumber, HexString, Script } from "@ckb-lumos/base";
+import { debug } from "../debug";
+
 interface LastL2BlockCommittedInfo {
   transaction_hash: Hash;
 }
@@ -35,11 +37,17 @@ export type PolyConfig = {
     };
   };
 };
-export class Godwoken {
+
+export class GodwokenV1 {
   private readonly rpc: RPC;
 
   constructor(url: string) {
     this.rpc = new RPC(url);
+  }
+
+  private async rpcCall(method_name: string, ...args: any[]): Promise<any> {
+    const name = "gw_" + method_name;
+    return this.rpc[name](...args);
   }
 
   /**
@@ -49,25 +57,20 @@ export class Godwoken {
    */
   async getChainId(): Promise<string> {
     const result = await this.rpc["eth_chainId"]();
-    console.debug("chain_id:", result);
+    debug("chain_id:", result);
     return result;
   }
 
   async getConfig(): Promise<PolyConfig> {
     const result = await this.rpc["poly_version"]();
-    console.debug("poly_version:", result);
+    debug("poly_version:", result);
     return result;
   }
 
   async getCkbBalance(address: HexString): Promise<string> {
     const result = await this.rpc["eth_getBalance"](address, "latest");
-    console.debug("eth_getBalance:", result);
+    debug("eth_getBalance:", result);
     return result;
-  }
-
-  private async rpcCall(method_name: string, ...args: any[]): Promise<any> {
-    const name = "gw_" + method_name;
-    return this.rpc[name](...args);
   }
 
   async submitWithdrawalRequest(data: HexString): Promise<Hash> {
@@ -87,6 +90,10 @@ export class Godwoken {
 
   async getScript(script_hash: Hash): Promise<Script> {
     return await this.rpcCall("get_script", script_hash);
+  }
+
+  async getScriptHash(account_id: HexNumber): Promise<Script> {
+    return await this.rpcCall("get_script_hash", account_id);
   }
 
   async getData(data_hash: Hash): Promise<HexString> {

--- a/packages/light-godwoken/src/godwoken/godwokenV1.ts
+++ b/packages/light-godwoken/src/godwoken/godwokenV1.ts
@@ -61,6 +61,10 @@ export class GodwokenV1 {
     return result;
   }
 
+  async getBlockNumber(): Promise<HexNumber> {
+    return this.rpc["eth_blockNumber"]();
+  }
+
   async getConfig(): Promise<PolyConfig> {
     const result = await this.rpc["poly_version"]();
     debug("poly_version:", result);
@@ -92,7 +96,7 @@ export class GodwokenV1 {
     return await this.rpcCall("get_script", script_hash);
   }
 
-  async getScriptHash(account_id: HexNumber): Promise<Script> {
+  async getScriptHash(account_id: HexNumber): Promise<Hash> {
     return await this.rpcCall("get_script_hash", account_id);
   }
 

--- a/packages/light-godwoken/src/godwoken/index.ts
+++ b/packages/light-godwoken/src/godwoken/index.ts
@@ -1,0 +1,2 @@
+export * from "./godwokenV0";
+export * from "./godwokenV1";

--- a/packages/light-godwoken/src/index.ts
+++ b/packages/light-godwoken/src/index.ts
@@ -11,6 +11,7 @@ export * from "./ethereumProvider";
 export * from "./schemas";
 export * from "./config";
 export * from "./tokens";
+export * from "./godwoken";
 export * from "./godwokenScanner";
 
 // Constants / Types

--- a/packages/light-godwoken/src/lightGodwokenType.ts
+++ b/packages/light-godwoken/src/lightGodwokenType.ts
@@ -242,7 +242,7 @@ export interface LightGodwokenBase {
 
   subscribPendingDepositTransactions: (payload: PendingDepositTransaction[]) => DepositEventEmitter;
 
-  withdrawWithEvent: (payload: WithdrawalEventEmitterPayload) => WithdrawalEventEmitter;
+  withdrawWithEvent: (payload: WithdrawalEventEmitterPayload, waitForCompletion?: boolean) => WithdrawalEventEmitter;
 
   l1Transfer: (payload: L1TransferPayload, eventEmitter?: EventEmitter) => Promise<Hash>;
 
@@ -264,6 +264,9 @@ export interface LightGodwokenBase {
 export interface LightGodwokenV0 extends LightGodwokenBase {
   getMinimalWithdrawalToV1Capacity(): BI;
   unlock: (payload: UnlockPayload) => Promise<Hash>;
-  withdrawToV1WithEvent: (payload: WithdrawalToV1EventEmitterPayload) => WithdrawalEventEmitter;
+  withdrawToV1WithEvent: (
+    payload: WithdrawalToV1EventEmitterPayload,
+    waitForCompletion?: boolean,
+  ) => WithdrawalEventEmitter;
 }
 export interface LightGodwokenV1 extends LightGodwokenBase {}

--- a/packages/light-godwoken/src/lightGodwokenType.ts
+++ b/packages/light-godwoken/src/lightGodwokenType.ts
@@ -236,9 +236,9 @@ export interface LightGodwokenBase {
 
   generateDepositAddress: (cancelTimeout?: number) => Address;
 
-  deposit: (payload: DepositPayload, eventEmitter: EventEmitter) => Promise<Hash>;
+  deposit: (payload: DepositPayload, eventEmitter?: EventEmitter, waitForCompletion?: boolean) => Promise<Hash>;
 
-  depositWithEvent: (payload: DepositPayload) => DepositEventEmitter;
+  depositWithEvent: (payload: DepositPayload, waitForCompletion?: boolean) => DepositEventEmitter;
 
   subscribPendingDepositTransactions: (payload: PendingDepositTransaction[]) => DepositEventEmitter;
 


### PR DESCRIPTION
### Description

There's a feature in deposit & withdrawal that if the caller has passed an `EventEmitter` into the deposit/withdraw function, it observes the deposit/withdrawal, which means it will keep requesting the RPC till the deposit/withdrawal has a result (or it will stop after too many cycles).

When I send a deposit/withdraw transaction, I might have to pass an EventEmitter into the function, but I don't always need to observe the result of the action. So I added a `waitForCompletion` option to both deposit and withdraw methods, so if `waitForCompletion !== true`, they just won't observe for the final result anymore.

### Changes
- Add `waitForCompletion` to deposit/withdraw
- Rename some classes
