### PR TITLE
Fix misplaced uan of `dCKB` and `YOK`

### DIFF
--- a/packages/light-godwoken/src/tokens/predefined/mainnet.ts
+++ b/packages/light-godwoken/src/tokens/predefined/mainnet.ts
@@ -13,6 +13,8 @@ export const MainnetTokenListV0: LightGodwokenToken[] = [
     l1LockArgs: "0xe5451c05231e1df43e4b199b5d12dbed820dfbea2769943bb593f874526eeb55",
     layer1UAN: "dCKB.ckb",
     layer2UAN: "dCKB.gw|gb.ckb",
+    layer1DisplayName: "dCKB",
+    layer2DisplayName: "dCKB (via GodwokenBridge from CKB)",
   },
   {
     id: 0,
@@ -24,6 +26,8 @@ export const MainnetTokenListV0: LightGodwokenToken[] = [
     l1LockArgs: "0x08430183dda1cbd81912c4762a3006a59e2291d5bd43b48bb7fa7544cace9e4a",
     layer1UAN: "TAI.ckb",
     layer2UAN: "TAI.gw|gb.ckb",
+    layer1DisplayName: "TAI",
+    layer2DisplayName: "TAI (via GodwokenBridge from CKB)",
   },
   {
     id: 0,
@@ -586,6 +590,8 @@ export const MainnetTokenListV1: LightGodwokenToken[] = [
     l1LockArgs: "0xe5451c05231e1df43e4b199b5d12dbed820dfbea2769943bb593f874526eeb55",
     layer1UAN: "dCKB.ckb",
     layer2UAN: "dCKB.gw|gb.ckb",
+    layer1DisplayName: "dCKB",
+    layer2DisplayName: "dCKB (via GodwokenBridge from CKB)",
   },
   {
     id: 0,
@@ -597,6 +603,8 @@ export const MainnetTokenListV1: LightGodwokenToken[] = [
     l1LockArgs: "0x08430183dda1cbd81912c4762a3006a59e2291d5bd43b48bb7fa7544cace9e4a",
     layer1UAN: "TAI.ckb",
     layer2UAN: "TAI.gw|gb.ckb",
+    layer1DisplayName: "TAI",
+    layer2DisplayName: "TAI (via GodwokenBridge from CKB)",
   },
   {
     id: 0,

--- a/packages/light-godwoken/src/tokens/predefined/mainnet.ts
+++ b/packages/light-godwoken/src/tokens/predefined/mainnet.ts
@@ -584,8 +584,8 @@ export const MainnetTokenListV1: LightGodwokenToken[] = [
     tokenURI: "https://cryptologos.cc/logos/nervos-network-ckb-logo.svg?v=002",
     address: "0x893474456C475E738b13DdA824979bF7a355DE39",
     l1LockArgs: "0xe5451c05231e1df43e4b199b5d12dbed820dfbea2769943bb593f874526eeb55",
-    layer1UAN: "YOK.ckb",
-    layer2UAN: "YOK.gw|gb.ckb",
+    layer1UAN: "dCKB.ckb",
+    layer2UAN: "dCKB.gw|gb.ckb",
   },
   {
     id: 0,

--- a/packages/light-godwoken/src/tokens/predefined/testnet.ts
+++ b/packages/light-godwoken/src/tokens/predefined/testnet.ts
@@ -11,6 +11,8 @@ export const TestnetTokenListV0: LightGodwokenToken[] = [
     l1LockArgs: "0x58bef38794236b315b7c23fd8132d7f42676228d659b291936e8c6c7ba9f064e",
     layer1UAN: "TTKN.ckb",
     layer2UAN: "TTKN.gw|gb.ckb",
+    layer1DisplayName: "TTKN",
+    layer2DisplayName: "TTKN (via GodwokenBridge from CKB)",
   },
   {
     id: 35,
@@ -77,6 +79,8 @@ export const TestnetTokenListV1: LightGodwokenToken[] = [
     l1LockArgs: "0x58bef38794236b315b7c23fd8132d7f42676228d659b291936e8c6c7ba9f064e",
     layer1UAN: "TTKN.ckb",
     layer2UAN: "TTKN.gw|gb.ckb",
+    layer1DisplayName: "TTKN",
+    layer2DisplayName: "TTKN (via GodwokenBridge from CKB)",
   },
   {
     id: 77042,


### PR DESCRIPTION
### Description

The UANs of `dCKB` (mainnet_v1) are incorrectly defined as: 
- `L1UAN` - YOK.ckb
- `L2UAN` - YOK.gw|gb.ckb

This makes `dCKB` and `YOK` share the same UANs, and can cause serious mistakes in the L1-Transfer page (displaying the wrong balance or choosing the wrong token since L1-Transfer page is using UAN as ID), which should be fixed by this PR. 

### Related issues
- https://github.com/godwokenrises/light-godwoken/issues/223
  Thanks to @Dawn-githup for spotting the issue.