### PR TITLE
Feat: update block produce time on v1 networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 > This feature gives developers an option to avoid listen to the final result of the deposit/withdrawal.
 > For more details, please visit: [Feat: add waitForCompletion to deposit/withdraw](https://github.com/godwokenrises/light-godwoken/pull/222).
 
+
 # 0.3.0 (2022-11-01)
 
 ### Bug Fixes

--- a/apps/godwoken-bridge/src/components/Withdrawal/SubmitWithdrawal.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/SubmitWithdrawal.tsx
@@ -102,7 +102,7 @@ const SubmitWithdrawal: React.FC<Props> = ({
         </TimeInfo>
         <TimeInfo>
           <MainText className="title">Estimated time</MainText>
-          <Text>{estimatedTime}</Text>
+          <Text>~{estimatedTime}</Text>
         </TimeInfo>
         <Tips>
           Layer 2 assets will be locked in Withdrawal Request, available to withdraw to Layer 1 after maturity.

--- a/packages/light-godwoken/src/config/predefined/mainnet.ts
+++ b/packages/light-godwoken/src/config/predefined/mainnet.ts
@@ -125,8 +125,7 @@ export const MainnetLayer2ConfigV1: LightGodwokenConfig = {
     SCANNER_API: "https://api.v1.gwscan.com/api/",
     CHAIN_NAME: "Godwoken Mainnet v1",
     FINALITY_BLOCKS: 16800,
-    // Assuming layer 1 block produce time is 12 seconds, layer 2 produces 1 block every 3 layer 1 blocks
-    BLOCK_PRODUCE_TIME: 12 * 3,
+    BLOCK_PRODUCE_TIME: 45, // L2 average block produce time from GwScan
     MIN_CANCEL_DEPOSIT_TIME: 604800,
 
     // https://github.com/mds1/multicall/commit/a6ed03f4bb232a573e9f6d4bdeca21a4edd3c1f7

--- a/packages/light-godwoken/src/config/predefined/testnet.ts
+++ b/packages/light-godwoken/src/config/predefined/testnet.ts
@@ -124,7 +124,7 @@ export const TestnetLayer2ConfigV1: LightGodwokenConfig = {
     SCANNER_API: "https://api.v1.betanet.gwscan.com/api/",
     CHAIN_NAME: "Godwoken Testnet v1",
     FINALITY_BLOCKS: 100,
-    BLOCK_PRODUCE_TIME: 30,
+    BLOCK_PRODUCE_TIME: 8, // L2 average block produce time from GwScan
     MIN_CANCEL_DEPOSIT_TIME: 604800, // 7 days in seconds
 
     // https://github.com/mds1/multicall/blob/a6ed03f4bb232a573e9f6d4bdeca21a4edd3c1f7/README.md


### PR DESCRIPTION
### Description
For the latest version of Godwoken V1, the withdrawal finality is relatively stable at:
- `mainnet` - 8.75 days
- `testnet` - 13 mins

So I changed the block produce time in our v1 configs to better match the current status. 

Also I've added a "~" in the withdrawal confirmation dialog, and when submitting, the dialog shows a rounded time.
For instance, on mainnet_v1 it shows `~9 days` instead of `8.75 days`:
```
Estimated time: ~9days
```

### Related issues:
- close https://github.com/godwokenrises/light-godwoken/issues/220
  Thanks to @alejandroRbit for pointing out the issue