### PR TITLE
Fix: ckb faucet should not be displayed on mainnet

### DIFF
--- a/apps/godwoken-bridge/src/components/PopoverMenu/index.tsx
+++ b/apps/godwoken-bridge/src/components/PopoverMenu/index.tsx
@@ -59,9 +59,11 @@ export function PopoverMenu({ onClick }: PopoverMenuProps) {
           <ClaimSudt />
         </div>
       )}
-      <PopoverMenuLink href="https://faucet.nervos.org" onClick={onClick}>
-        Claim CKB Faucet on L1
-      </PopoverMenuLink>
+      {!isMainnet && (
+        <PopoverMenuLink href="https://faucet.nervos.org" onClick={onClick}>
+          Claim CKB Faucet on L1
+        </PopoverMenuLink>
+      )}
       <PopoverMenuLink href="https://docs.godwoken.io" onClick={onClick}>
         Godwoken Docs
       </PopoverMenuLink>


### PR DESCRIPTION
Godwoken Bridge incorrectly shows CKB Faucet link on mainnet.
Adding diplay logic to fix the issue.