### PR TITLE
ci: replace set-output syntax and upgrade dep actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,12 @@ jobs:
   test-unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -24,7 +24,7 @@ jobs:
           yarn --ignore-engines --frozen-lockfile
           yarn run test:coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./coverage/cobertura-coverage.xml


### PR DESCRIPTION
### Description
GitHub is deprecating `set-output`, `save-state` and `node@12` on GitHub Actions.
To make sure everything works in the future, in this PR we should:
- Replace all `set-output` syntax to be in sync with latest standard
- Upgrade dependency actions to get rid of deprecated `node@12` and `save-state`

### Related materials
- [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)