### PR TITLE
Chore: bump v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+# 0.3.2 (2022-12-1)
+
+### Bug Fixes
+* Fix ckb faucet display logic on mainnet ([#232](https://github.com/godwokenrises/light-godwoken/pull/232))
+
+### Features
+* Update block produce time on v1 networks ([#231](https://github.com/godwokenrises/light-godwoken/pull/231))
+> We have updated the average block produce time on Godwoken Bridge so the estimated withdrawal time left is displayed more accurately. Thanks to @alejandroRbit for the suggestion.
+
+* Support dotbit forward/reverse search features ([#234](https://github.com/godwokenrises/light-godwoken/pull/234))
+> Dotbit is now supported by Godwoken Bridge. You can check your dotbit alias on Godwoken Bridge. And when l1-transferring, you can enter the recipient's dotbit account and select an address to transfer assets instead of copying and pasting a CKB address.
 
 
 # 0.3.1 (2022-11-10)

--- a/apps/godwoken-bridge/package.json
+++ b/apps/godwoken-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godwoken-bridge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "start": "react-scripts start",
@@ -53,7 +53,7 @@
     "date-fns": "^2.28.0",
     "dotbit": "^0.4.11",
     "events": "^3.3.0",
-    "light-godwoken": "^0.3.1",
+    "light-godwoken": "^0.3.2",
     "numeral": "^2.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.3.2",
   "packages": [
     "packages/**",
     "apps/**",

--- a/packages/light-godwoken/package.json
+++ b/packages/light-godwoken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-godwoken",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
### Changes
- Publish light-godwoken v0.3.2
- Update [CHANGELOG.md](https://github.com/godwokenrises/light-godwoken/blob/939a890bb386c0ece27126ae0cbf7a1971ccf52d/CHANGELOG.md)