### PR TITLE
Feat: improve the display logic of pending withdrawals

### DIFF
--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -100,7 +100,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
         reloadWithdrawalHistory();
         intervalReloadHistory();
       }
-    }, 30000);
+    }, 60000);
   }, [isPending, reloadWithdrawalHistory]);
   useEffect(() => {
     intervalReloadHistory();

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
@@ -208,25 +208,21 @@ const WithdrawalRequestCard = ({
           </div>
         </div>
         <div className="right-side">
-          {status === "pending" && shouldShowMore && (
+          {status === "pending" && !isDue && shouldShowMore && (
             <div className="time">
               <ArrowUpIcon />
             </div>
           )}
-          {status === "pending" && !shouldShowMore && (
+          {status === "pending" && !isDue && !shouldShowMore && (
             <div className="time">
-              {isDue && (
-                <Tooltip title="Unlocking withdrawal">
-                  <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
-                </Tooltip>
-              )}
-              {!isDue && (
-                <>
-                  <MainText title="Estimated time left">{countdownText}</MainText>
-                  <ArrowDownIcon />
-                </>
-              )}
+              <MainText title="Estimated time left">{countdownText}</MainText>
+              <ArrowDownIcon />
             </div>
+          )}
+          {status === "pending" && isDue && !shouldShowMore && (
+            <Tooltip title="Unlocking withdrawal">
+              <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
+            </Tooltip>
           )}
           {status === "available" && hasOutpoint && !matchedUnlockHistory && isLiveCell === true && (
             <Tooltip title="Unlock withdrawal to your address">

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -126,7 +126,7 @@ const WithdrawalRequestCard = ({
     [blockProduceTime, remainingBlockNumber],
   );
   const estimatedSecondsLeft = useMemo(() => Math.max(0, estimatedArrivalDate - now), [now, estimatedArrivalDate]);
-  const isMature = useMemo(() => remainingBlockNumber === 0, [remainingBlockNumber]);
+  const isMature = useMemo(() => estimatedSecondsLeft === 0, [estimatedSecondsLeft]);
 
   const {
     days: daysLeft,
@@ -178,7 +178,7 @@ const WithdrawalRequestCard = ({
               <ArrowDownIcon />
             </div>
           )}
-          {status === "pending" && isMature && (
+          {((status === "pending" && isMature) || status === "available") && (
             <Tooltip title="Unlocking withdrawal">
               <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
             </Tooltip>

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -10,7 +10,7 @@ import { ReactComponent as ArrowDownIcon } from "../../assets/arrow-down.svg";
 import { ReactComponent as ArrowUpIcon } from "../../assets/arrow-up.svg";
 import { MainText } from "../../style/common";
 import { COLOR } from "../../style/variables";
-import { CheckCircleOutlined, CloseCircleOutlined, QuestionCircleOutlined } from "@ant-design/icons";
+import { CheckCircleOutlined, CloseCircleOutlined, LoadingOutlined, QuestionCircleOutlined } from "@ant-design/icons";
 import { Tooltip } from "antd";
 import { useClock } from "../../hooks/useClock";
 import { TokenInfoWithAmount } from "./TokenInfoWithAmount";
@@ -162,22 +162,27 @@ const WithdrawalRequestCard = ({
           </div>
         </div>
         <div className="right-side">
-          {status === "pending" &&
-            (shouldShowMore ? (
-              <div className="time">
-                <ArrowUpIcon />
-              </div>
-            ) : (
-              <div className="time">
-                <MainText title="Estimated time left">
-                  {daysLeft ? `${daysLeft} day${daysLeft > 1 ? "s" : ""}, ` : ""}
-                  {hoursLeft ? `${hoursLeft.toString().padStart(2, "0")}:` : ""}
-                  {`${minutesLeft.toString().padStart(2, "0")}:`}
-                  {`${secondsLeft.toString().padStart(2, "0")}`}
-                </MainText>
-                <ArrowDownIcon />
-              </div>
-            ))}
+          {status === "pending" && !isMature && shouldShowMore && (
+            <div className="time">
+              <ArrowUpIcon />
+            </div>
+          )}
+          {status === "pending" && !isMature && !shouldShowMore && (
+            <div className="time">
+              <MainText title="Estimated time left">
+                {daysLeft ? `${daysLeft} day${daysLeft > 1 ? "s" : ""}, ` : ""}
+                {hoursLeft ? `${hoursLeft.toString().padStart(2, "0")}:` : ""}
+                {`${minutesLeft.toString().padStart(2, "0")}:`}
+                {`${secondsLeft.toString().padStart(2, "0")}`}
+              </MainText>
+              <ArrowDownIcon />
+            </div>
+          )}
+          {status === "pending" && isMature && (
+            <Tooltip title="Unlocking withdrawal">
+              <LoadingOutlined style={{ color: "#484848", height: "21px", lineHeight: "21px" }} />
+            </Tooltip>
+          )}
           {status === "succeed" && (
             <Tooltip title={status}>
               <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5112,18 +5112,6 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-"acorn-base@npm:acorn@^7.3.1":
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn-class-fields@^0.3.7:
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/acorn-class-fields/-/acorn-class-fields-0.3.7.tgz#a35122f3cc6ad2bb33b1857e79215677fcfdd720"
-  integrity sha512-jdUWSFce0fuADUljmExz4TWpPkxmRW/ZCPRqeeUzbGf0vFUcpQYbyq52l75qGd0oSwwtAepeL6hgb/naRgvcKQ==
-  dependencies:
-    acorn-private-class-elements "^0.2.7"
-
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz"
@@ -5137,46 +5125,6 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-logical-assignment@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/acorn-logical-assignment/-/acorn-logical-assignment-0.1.4.tgz#1a143a21f022e1707b2bc82f587ae2943f0a570e"
-  integrity sha512-SeqO1iRtc/NeXo4bTkyK0hN0CIoKi/FQMN1NqhTr5UxqEn4p2wKNTZl+xzvU7i2u/k0f66YR7pNPi2ckPwYubg==
-
-acorn-numeric-separator@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/acorn-numeric-separator/-/acorn-numeric-separator-0.3.6.tgz#af7f0abaf8e74bd9ca1117602954d0a3b75804f3"
-  integrity sha512-jUr5esgChu4k7VzesH/Nww3EysuyGJJcTEEiXqILUFKpO96PNyEXmK21M6nE0TSqGA1PeEg1MzgqJaoFsn9JMw==
-
-acorn-private-class-elements@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/acorn-private-class-elements/-/acorn-private-class-elements-0.2.7.tgz#b14902c705bcff267adede1c9f61c1a317ef95d2"
-  integrity sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA==
-
-acorn-private-methods@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/acorn-private-methods/-/acorn-private-methods-0.3.3.tgz#724414ce5b2fec733089d73a5cbba8f7beff75b1"
-  integrity sha512-46oeEol3YFvLSah5m9hGMlNpxDBCEkdceJgf01AjqKYTK9r6HexKs2rgSbLK81pYjZZMonhftuUReGMlbbv05w==
-  dependencies:
-    acorn-private-class-elements "^0.2.7"
-
-acorn-stage3@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-stage3/-/acorn-stage3-3.1.0.tgz#545dea4d78c8405190463fc8e79413273e7b19f0"
-  integrity sha512-iKDUmzlsw5Rs3lOTCuq3lcOddHTn3xX9gpCfoXSXAr5E9IxqJWkECKBVcSYJZRCaiNGCGNops87AdB8I1fIl2A==
-  dependencies:
-    acorn-class-fields "^0.3.7"
-    acorn-logical-assignment "^0.1.4"
-    acorn-numeric-separator "^0.3.6"
-    acorn-private-methods "^0.3.3"
-    acorn-static-class-features "^0.2.4"
-
-acorn-static-class-features@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/acorn-static-class-features/-/acorn-static-class-features-0.2.4.tgz#a0f5261dd483f25196716854f2d7652a1deb39ee"
-  integrity sha512-5X4mpYq5J3pdndLmIB0+WtFd/mKWnNYpuTlTzj32wUu/PMmEGOiayQ5UrqgwdBNiaZBtDDh5kddpP7Yg2QaQYA==
-  dependencies:
-    acorn-private-class-elements "^0.2.7"
-
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
@@ -5187,13 +5135,20 @@ acorn-walk@^8.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^6.4.1, acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^8.2.4, acorn@^8.4.1, acorn@^8.6.0, "acorn@npm:acorn-with-stage3":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/acorn-with-stage3/-/acorn-with-stage3-1.0.2.tgz#7ab1d6aa346072f8c6b19c8ef7eb0fc26cb89756"
-  integrity sha512-9RQEyavZ1djNZJrT1QH7yu0OpgcLtlTZHMK22N1tD7O+sXnXfGCT1kbgtFtCu47Rf05ddV9XNVzqFANU2CuF1Q==
-  dependencies:
-    acorn-base "npm:acorn@^7.3.1"
-    acorn-stage3 "^3.0.0"
+acorn@^6.4.1:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+
+acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.2.4, acorn@^8.4.1, acorn@^8.6.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -16337,7 +16292,7 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==


### PR DESCRIPTION
### Description
Previously, pending v1 withdrawals were not properly displayed while waiting to be unlocked.
Now added the logic: when a withdrawal's time is up, it will show a loading indicator instead of "00:00".
Also to improve user experience, I added an interval which reloads the v1 pending withdrawal list every 60 seconds.

Thanks to @Dawn-githup for the suggestion.

### Changes
- Provides a loading indicator for pending/available withdrawals waiting to be unlocked
- Adds an interval to reload the v1 pending withdrawal list at every 30 seconds
- Update yarn.lock file