### PR TITLE
Feat: remove instant-finality-hack from rpc url

### DIFF
--- a/packages/light-godwoken/src/config/predefined/testnet.ts
+++ b/packages/light-godwoken/src/config/predefined/testnet.ts
@@ -119,7 +119,7 @@ export const TestnetLayer2ConfigV1: LightGodwokenConfig = {
         args: "0x86c7429247beba7ddd6e4361bcdfc0510b0b644131e2afb7e486375249a01802",
       },
     },
-    GW_POLYJUICE_RPC_URL: "https://v1.testnet.godwoken.io/rpc/instant-finality-hack",
+    GW_POLYJUICE_RPC_URL: "https://v1.testnet.godwoken.io/rpc",
     SCANNER_URL: "https://v1.testnet.gwscan.com/",
     SCANNER_API: "https://api.v1.betanet.gwscan.com/api/",
     CHAIN_NAME: "Godwoken Testnet v1",


### PR DESCRIPTION
After updating the RPC URL for Testnet v1, we found an issue in MetaMask that it doesn't like RPC URLs that aren't in the [chainlist](https://github.com/ethereum-lists/chains/blob/fb49612d701926525629ba3f1836d2a58f3475ad/_data/chains/eip155-71401.json) records. The detailed behaviour is that when godwoken-bridge calls the `wallet_addEthereumChain` method, MetaMask warns the user that the new network is not in their record.

After discussion, we decided to remove the `instant-finality-hack` from the RPC URLs in light-godwoken, as this feature is now optional and does not affect operations in light-godwoken. 

Also, we have created a PR to update the info of Godwoken Testnet v1 chain: https://github.com/ethereum-lists/chains/pull/1979.