### PR TITLE
Ref: migrate ckb-lumos to the latest version

### DIFF
--- a/apps/godwoken-bridge/craco.config.js
+++ b/apps/godwoken-bridge/craco.config.js
@@ -1,9 +1,23 @@
 // const SentryPlugin = require("@sentry/webpack-plugin");
 
 function getProductionSetting() {
-  if (process.env.NODE_ENV !== "production") return {};
-  return {
+  /*if (process.env.NODE_ENV !== "production") return {
     presets: ["@babel/preset-env"],
+  };*/
+  return {
+    presets: [
+      [
+        "@babel/preset-env",
+        {
+          loose: false,
+        },
+      ],
+    ],
+    plugins: [
+      "@babel/plugin-proposal-private-property-in-object",
+      "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-proposal-private-methods",
+    ],
   };
 }
 

--- a/apps/godwoken-bridge/package.json
+++ b/apps/godwoken-bridge/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.3",
   "private": true,
   "scripts": {
-    "start": "react-scripts start",
+    "start": "craco start",
     "build": "REACT_APP_COMMIT_HASH=$(git rev-parse --short HEAD) craco --max_old_space_size=4096  build",
     "clean": "rm -rf ./dist && rm tsconfig.tsbuildinfo",
     "format:check": "prettier --check '**/*.{js,jsx,ts,tsx}'",
@@ -33,8 +33,9 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
-    "@ckb-lumos/bi": "^0.17.0",
-    "@ckb-lumos/lumos": "^0.17.0",
+    "@ckb-lumos/bi": "^0.20.0-alpha.1",
+    "@ckb-lumos/lumos": "^0.20.0-alpha.1",
+    "@ckb-lumos/codec": "^0.20.0-alpha.1",
     "@metamask/detect-provider": "^1.2.0",
     "@metamask/providers": "^8.1.1",
     "@rehooks/local-storage": "^2.4.4",

--- a/apps/godwoken-bridge/src/components/Deposit/List.tsx
+++ b/apps/godwoken-bridge/src/components/Deposit/List.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 import React, { useEffect, useRef } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { number } from "@ckb-lumos/codec";
 import { useInfiniteScroll } from "ahooks";
-import { utils } from "@ckb-lumos/lumos";
 import { format } from "date-fns";
 import { AxiosError } from "axios";
 import { LightGodwoken } from "light-godwoken";
@@ -39,7 +39,7 @@ export const DepositList: React.FC<DepositListParams> = ({ depositList, isLoadin
       const history = await getDepositHistories(lightGodwoken!, page);
       const list = history.map((deposit): DepositHistoryType => {
         const date = format(new Date(deposit.history.timestamp), "yyyy-MM-dd HH:mm:ss");
-        const sudtAmount = deposit.sudt ? utils.readBigUInt128LECompatible(deposit.cell.data).toHexString() : "0x0";
+        const sudtAmount = deposit.sudt ? number.Uint128LE.unpack(deposit.cell.data).toHexString() : "0x0";
 
         return {
           txHash: deposit.history.layer1_tx_hash || "",

--- a/apps/godwoken-bridge/src/components/L1Transfer/RequestL1Transfer.tsx
+++ b/apps/godwoken-bridge/src/components/L1Transfer/RequestL1Transfer.tsx
@@ -39,8 +39,8 @@ const CkbAsSudt: SUDT = {
   decimals: 8,
   tokenURI: CkbSvg,
   type: {
-    hash_type: "0x" as HashType,
-    code_hash: "0x",
+    hashType: "0x" as HashType,
+    codeHash: "0x",
     args: "0x",
   },
 };

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -44,6 +44,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
     async (data) => {
       const page = data?.page ? data.page + 1 : 1;
       const list = await getWithdrawalHistories(lightGodwoken as LightGodwokenV1, page);
+      console.log("list", list);
 
       return {
         list,

--- a/apps/godwoken-bridge/src/components/Withdrawal/Unlock.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/Unlock.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from "react";
 import styled from "styled-components";
 import { notification, Tooltip } from "antd";
-import { BI, Cell, Hash, utils } from "@ckb-lumos/lumos";
+import { number } from "@ckb-lumos/codec";
+import { BI, Cell, Hash } from "@ckb-lumos/lumos";
 import { captureException } from "@sentry/react";
 import { LoadingOutlined } from "@ant-design/icons";
 import { NotEnoughCapacityError, ProxyERC20, TransactionSignError } from "light-godwoken";
@@ -81,12 +82,12 @@ const Unlock: React.FC<UnlockProps> = ({ layer1TxHash, erc20, cell }) => {
 
   // ckb capacity
   const ckbCapacity = useMemo(() => {
-    return getDisplayAmount(BI.from(cell.cell_output.capacity), 8);
-  }, [cell.cell_output.capacity]);
+    return getDisplayAmount(BI.from(cell.cellOutput.capacity), 8);
+  }, [cell.cellOutput.capacity]);
 
   // sudt
   const amount = useMemo(() => {
-    return cell.cell_output.type ? utils.readBigUInt128LECompatible(cell.data) : "0x0";
+    return cell.cellOutput.type ? number.Uint128LE.unpack(cell.data) : "0x0";
   }, [cell]);
 
   if (lightGodwoken?.getVersion().toString() !== "v0") {

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV0.tsx
@@ -140,7 +140,7 @@ const WithdrawalRequestCard = ({
   );
   const estimatedSecondsLeft = useMemo(() => Math.max(0, estimatedArrivalDate - now), [now, estimatedArrivalDate]);
   const isMature = useMemo(() => remainingBlockNumber === 0, [remainingBlockNumber]);
-  const hasOutpoint = useMemo(() => cell?.out_point !== void 0, [cell]);
+  const hasOutpoint = useMemo(() => cell?.outPoint !== void 0, [cell]);
   const matchedUnlockHistory = useMemo(() => {
     return layer1TxHash ? unlockHistory.find((row) => row.withdrawalTxHash === layer1TxHash) : void 0;
   }, [unlockHistory, layer1TxHash]);
@@ -151,7 +151,7 @@ const WithdrawalRequestCard = ({
     async function updateIsLiveCell() {
       if (status === "available" && hasOutpoint) {
         setIsLoadingLiveCell(true);
-        const liveCell = await lightGodwoken!.provider.ckbRpc.get_live_cell(cell!.out_point!, false);
+        const liveCell = await lightGodwoken!.provider.ckbRpc.getLiveCell(cell!.outPoint!, false);
         setIsLiveCell(liveCell.status === "live");
       } else {
         setIsLiveCell(false);

--- a/apps/godwoken-bridge/src/views/Deposit.tsx
+++ b/apps/godwoken-bridge/src/views/Deposit.tsx
@@ -98,12 +98,12 @@ export default function Deposit() {
   // append rpc fetched deposit list to local storage
   const { data: depositList, isLoading: depositListLoading } = depositListQuery;
   depositList?.forEach((deposit) => {
-    if (!depositHistoryTxHashes.includes(deposit.rawCell.out_point?.tx_hash || "")) {
+    if (!depositHistoryTxHashes.includes(deposit.rawCell.outPoint?.txHash || "")) {
       addTxToHistory({
         capacity: deposit.capacity.toHexString(),
         amount: deposit.amount.toHexString(),
         token: deposit.sudt,
-        txHash: deposit.rawCell.out_point?.tx_hash || "",
+        txHash: deposit.rawCell.outPoint?.txHash || "",
         status: "pending",
         date: format(new Date(), "yyyy-MM-dd HH:mm:ss"),
         cancelTimeout,
@@ -117,7 +117,7 @@ export default function Deposit() {
 
   useMemo(() => {
     const pendingList = depositHistory.filter((history) => history.status === "pending");
-    const subscribePayload = pendingList.map(({ txHash }) => ({ tx_hash: txHash }));
+    const subscribePayload = pendingList.map(({ txHash }) => ({ txHash }));
     const listener = lightGodwoken?.subscribPendingDepositTransactions(subscribePayload);
     if (listener) {
       listener.on("success", (txHash) => {

--- a/packages/light-godwoken/package.json
+++ b/packages/light-godwoken/package.json
@@ -17,10 +17,10 @@
     "dist"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "^0.17.0",
-    "@ckb-lumos/bi": "^0.17.0",
-    "@ckb-lumos/codec": "^0.17.0",
-    "@ckb-lumos/lumos": "^0.17.0",
+    "@ckb-lumos/base": "^0.20.0-alpha.1",
+    "@ckb-lumos/bi": "^0.20.0-alpha.1",
+    "@ckb-lumos/codec": "^0.20.0-alpha.1",
+    "@ckb-lumos/lumos": "^0.20.0-alpha.1",
     "@polyjuice-provider/base": "^0.1.1",
     "@polyjuice-provider/ethers": "^0.1.5",
     "@polyjuice-provider/godwoken": "^0.1.1",

--- a/packages/light-godwoken/src/__tests__/clientConfig.ts
+++ b/packages/light-godwoken/src/__tests__/clientConfig.ts
@@ -4,26 +4,26 @@ import { predefinedTokens } from "../tokens";
 
 const layer1ConfigAggron: Layer1Config = {
   SCRIPTS: {
-    omni_lock: {
-      code_hash: "0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e",
-      hash_type: "type",
-      tx_hash: "0x9154df4f7336402114d04495175b37390ce86a4906d2d4001cf02c3e6d97f39c",
+    omniLock: {
+      codeHash: "0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e",
+      hashType: "type",
+      txHash: "0x9154df4f7336402114d04495175b37390ce86a4906d2d4001cf02c3e6d97f39c",
       index: "0x0",
-      dep_type: "code",
+      depType: "code",
     },
-    secp256k1_blake160: {
-      code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-      hash_type: "type",
-      tx_hash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
+    secp256k1Blake160: {
+      codeHash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hashType: "type",
+      txHash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
       index: "0x0",
-      dep_type: "dep_group",
+      depType: "depGroup",
     },
     sudt: {
-      code_hash: "0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4",
-      hash_type: "type",
-      tx_hash: "0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769",
+      codeHash: "0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4",
+      hashType: "type",
+      txHash: "0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769",
       index: "0x0",
-      dep_type: "code",
+      depType: "code",
     },
   },
   CKB_INDEXER_URL: "https://testnet.ckb.dev/indexer",
@@ -37,35 +37,35 @@ export const testConfig: LightGodwokenConfigMap = {
     layer1Config: layer1ConfigAggron,
     layer2Config: {
       SCRIPTS: {
-        deposit_lock: {
-          script_type_hash: "0x5a2506bb68d81a11dcadad4cb7eae62a17c43c619fe47ac8037bc8ce2dd90360",
-          cell_dep: {
-            out_point: {
-              tx_hash: "0x9caeec735f3cd2a60b9d12be59bb161f7c61ddab1ac22c4383a94c33ba6404a2",
+        depositLock: {
+          scriptTypeHash: "0x5a2506bb68d81a11dcadad4cb7eae62a17c43c619fe47ac8037bc8ce2dd90360",
+          cellDep: {
+            outPoint: {
+              txHash: "0x9caeec735f3cd2a60b9d12be59bb161f7c61ddab1ac22c4383a94c33ba6404a2",
               index: "0x0",
             },
-            dep_type: "code",
+            depType: "code",
           },
         },
-        withdrawal_lock: {
-          script_type_hash: "0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5",
-          cell_dep: {
-            out_point: {
-              tx_hash: "0xb4b07dcd1571ac18683b515ada40e13b99bd0622197b6817047adc9f407f4828",
+        withdrawalLock: {
+          scriptTypeHash: "0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5",
+          cellDep: {
+            outPoint: {
+              txHash: "0xb4b07dcd1571ac18683b515ada40e13b99bd0622197b6817047adc9f407f4828",
               index: "0x0",
             },
-            dep_type: "code",
+            depType: "code",
           },
         },
-        eth_account_lock: {
-          script_type_hash: "0xdeec13a7b8e100579541384ccaf4b5223733e4a5483c3aec95ddc4c1d5ea5b22",
+        ethAccountLock: {
+          scriptTypeHash: "0xdeec13a7b8e100579541384ccaf4b5223733e4a5483c3aec95ddc4c1d5ea5b22",
         },
       },
       ROLLUP_CONFIG: {
-        rollup_type_hash: "0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6a",
-        rollup_type_script: {
-          code_hash: "0x5c365147bb6c40e817a2a53e0dec3661f7390cc77f0c02db138303177b12e9fb",
-          hash_type: "type",
+        rollupTypeHash: "0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6a",
+        rollupTypeScript: {
+          codeHash: "0x5c365147bb6c40e817a2a53e0dec3661f7390cc77f0c02db138303177b12e9fb",
+          hashType: "type",
           args: "0x213743d13048e9f36728c547ab736023a7426e15a3d7d1c82f43ec3b5f266df2",
         },
       },
@@ -84,35 +84,35 @@ export const testConfig: LightGodwokenConfigMap = {
     layer1Config: layer1ConfigAggron,
     layer2Config: {
       SCRIPTS: {
-        deposit_lock: {
-          script_type_hash: "0x50704b84ecb4c4b12b43c7acb260ddd69171c21b4c0ba15f3c469b7d143f6f18",
-          cell_dep: {
-            out_point: {
-              tx_hash: "0x9caeec735f3cd2a60b9d12be59bb161f7c61ddab1ac22c4383a94c33ba6404a2",
+        depositLock: {
+          scriptTypeHash: "0x50704b84ecb4c4b12b43c7acb260ddd69171c21b4c0ba15f3c469b7d143f6f18",
+          cellDep: {
+            outPoint: {
+              txHash: "0x9caeec735f3cd2a60b9d12be59bb161f7c61ddab1ac22c4383a94c33ba6404a2",
               index: "0x0",
             },
-            dep_type: "code",
+            depType: "code",
           },
         },
-        withdrawal_lock: {
-          script_type_hash: "0x06ae0706bb2d7997d66224741d3ec7c173dbb2854a6d2cf97088796b677269c6",
-          cell_dep: {
-            out_point: {
-              tx_hash: "0x9c607a9a75ea4699dd01b1c2a478002343998cac8346d2aa582f35b532bd2b93",
+        withdrawalLock: {
+          scriptTypeHash: "0x06ae0706bb2d7997d66224741d3ec7c173dbb2854a6d2cf97088796b677269c6",
+          cellDep: {
+            outPoint: {
+              txHash: "0x9c607a9a75ea4699dd01b1c2a478002343998cac8346d2aa582f35b532bd2b93",
               index: "0x0",
             },
-            dep_type: "code",
+            depType: "code",
           },
         },
-        eth_account_lock: {
-          script_type_hash: "0x07521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec0",
+        ethAccountLock: {
+          scriptTypeHash: "0x07521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec0",
         },
       },
       ROLLUP_CONFIG: {
-        rollup_type_hash: "0x702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd8",
-        rollup_type_script: {
-          code_hash: "0x1e44736436b406f8e48a30dfbddcf044feb0c9eebfe63b0f81cb5bb727d84854",
-          hash_type: "type",
+        rollupTypeHash: "0x702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd8",
+        rollupTypeScript: {
+          codeHash: "0x1e44736436b406f8e48a30dfbddcf044feb0c9eebfe63b0f81cb5bb727d84854",
+          hashType: "type",
           args: "0x86c7429247beba7ddd6e4361bcdfc0510b0b644131e2afb7e486375249a01802",
         },
       },

--- a/packages/light-godwoken/src/__tests__/codec.spec.ts
+++ b/packages/light-godwoken/src/__tests__/codec.spec.ts
@@ -1,17 +1,19 @@
-import { BI, core, toolkit } from "@ckb-lumos/lumos";
+import { BI } from "@ckb-lumos/lumos";
+import { bytes } from "@ckb-lumos/codec";
+import { blockchain } from "@ckb-lumos/base";
 import { V0DepositLockArgs } from "../schemas/codecV0";
 import { V1DepositLockArgs } from "../schemas/codecV1";
 import { OmniLockWitnessLockCodec } from "../schemas/codecLayer1";
 describe("test codec", () => {
   it("should codec omnilock", async () => {
     const signature = "0x22506400d99d605caa6a047ea3146a0ef8ac87ad38cb4549b64ca025640315f6";
-    const serilized = new toolkit.Reader(
-      core.SerializeWitnessArgs({
+    const serialized = bytes.hexify(
+      blockchain.WitnessArgs.pack({
         lock: OmniLockWitnessLockCodec.pack({ signature }).buffer,
       }),
-    ).serializeJson();
+    );
 
-    expect(serilized).toEqual(
+    expect(serialized).toEqual(
       "0x4800000010000000480000004800000034000000340000001000000034000000340000002000000022506400d99d605caa6a047ea3146a0ef8ac87ad38cb4549b64ca025640315f6",
     );
   });
@@ -25,9 +27,9 @@ describe("test codec", () => {
       },
       cancel_timeout: BI.from("0xc0000000000004b0"),
     };
-    const serilized = new toolkit.Reader(V0DepositLockArgs.pack(depositArgs).buffer).serializeJson();
+    const serialized = bytes.hexify(V0DepositLockArgs.pack(depositArgs).buffer);
 
-    expect(serilized).toEqual(
+    expect(serialized).toEqual(
       "0xa1000000100000003000000099000000ea8e5a6ed260ee56af7d66ddb8c7c09a3ade6c38d207c30a6d11b3d8e11387df6900000010000000300000003100000007521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec00134000000702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd862a67949836b389ec146b3b2187e949f7faef679b0040000000000c0",
     );
   });
@@ -42,9 +44,9 @@ describe("test codec", () => {
       cancel_timeout: BI.from("0xc000000000093a81"),
       registry_id: 2,
     };
-    const serilized = new toolkit.Reader(V1DepositLockArgs.pack(depositArgs).buffer).serializeJson();
+    const serialized = bytes.hexify(V1DepositLockArgs.pack(depositArgs).buffer);
 
-    expect(serilized).toEqual(
+    expect(serialized).toEqual(
       "0xa900000014000000340000009d000000a5000000ea8e5a6ed260ee56af7d66ddb8c7c09a3ade6c38d207c30a6d11b3d8e11387df6900000010000000300000003100000007521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec00134000000702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd862a67949836b389ec146b3b2187e949f7faef679813a0900000000c002000000",
     );
   });

--- a/packages/light-godwoken/src/__tests__/lightGodwoken.spec.ts
+++ b/packages/light-godwoken/src/__tests__/lightGodwoken.spec.ts
@@ -27,7 +27,7 @@ describe("test light godwoken generateDepositOutputCell", () => {
       capacity: BI.from(400e8).toHexString(),
     });
     expect(outputCells.length).toEqual(1);
-    expect(outputCells[0].cell_output.capacity).toEqual(BI.from(400e8).toHexString());
+    expect(outputCells[0].cellOutput.capacity).toEqual(BI.from(400e8).toHexString());
   });
   it("should deposit 400 CKB, 300 pure CKB and 100 free CKB", async () => {
     const typeScript: Script = randomSudtTypeScript(lightGodwokenV1.getConfig());
@@ -38,9 +38,9 @@ describe("test light godwoken generateDepositOutputCell", () => {
     });
     const [sudtExchangeCell, depositCell] = outputCells;
     expect(outputCells.length).toEqual(2);
-    expect(sudtExchangeCell.cell_output.capacity).toEqual(BI.from(144e8).toHexString());
-    expect(sudtExchangeCell.cell_output.type).toEqual(typeScript);
-    expect(depositCell.cell_output.capacity).toEqual(BI.from(400e8).toHexString());
+    expect(sudtExchangeCell.cellOutput.capacity).toEqual(BI.from(144e8).toHexString());
+    expect(sudtExchangeCell.cellOutput.type).toEqual(typeScript);
+    expect(depositCell.cellOutput.capacity).toEqual(BI.from(400e8).toHexString());
   });
   it("should deposit 400 CKB, 250 pure CKB and 100 from free CKB and 50 from sudt cell", async () => {
     const freeTypeScript: Script = randomSudtTypeScript(lightGodwokenV1.getConfig());
@@ -56,15 +56,15 @@ describe("test light godwoken generateDepositOutputCell", () => {
     const [sudtExchangeCell, depositCell, ckbExchangeCell] = outputCells;
     expect(outputCells.length).toEqual(3);
     // output 0 is free ckb provider cell after taken free ckb away
-    expect(sudtExchangeCell.cell_output.capacity).toEqual(BI.from(144e8).toHexString());
-    expect(sudtExchangeCell.cell_output.type).toEqual(freeTypeScript);
+    expect(sudtExchangeCell.cellOutput.capacity).toEqual(BI.from(144e8).toHexString());
+    expect(sudtExchangeCell.cellOutput.type).toEqual(freeTypeScript);
     // output 1 is deposit cell
-    expect(depositCell.cell_output.capacity).toEqual(BI.from(400e8).toHexString());
-    expect(depositCell.cell_output.type).toEqual(depositSudtTypeScript);
+    expect(depositCell.cellOutput.capacity).toEqual(BI.from(400e8).toHexString());
+    expect(depositCell.cellOutput.type).toEqual(depositSudtTypeScript);
     // output 2 is exchangecell
-    expect(ckbExchangeCell.cell_output.capacity).toEqual(BI.from(144e8).toHexString());
-    expect(ckbExchangeCell.cell_output.type).toEqual(undefined);
-    expect(ckbExchangeCell.cell_output.lock).toEqual(lightGodwokenV1.provider.getLayer1Lock());
+    expect(ckbExchangeCell.cellOutput.capacity).toEqual(BI.from(144e8).toHexString());
+    expect(ckbExchangeCell.cellOutput.type).toEqual(undefined);
+    expect(ckbExchangeCell.cellOutput.lock).toEqual(lightGodwokenV1.provider.getLayer1Lock());
   });
   it("should generateDepositTx if user deposit 400 CKB, and user has 250 pure CKB and 100 from free CKB and 50 from sudt cell", async () => {
     const freeTypeScript: Script = randomSudtTypeScript(lightGodwokenV1.getConfig());

--- a/packages/light-godwoken/src/__tests__/lightGodwokenDeposit.spec.ts
+++ b/packages/light-godwoken/src/__tests__/lightGodwokenDeposit.spec.ts
@@ -85,8 +85,8 @@ describe("test light godwoken v1 deposit", () => {
     const lock = await lightGodwokenV1.generateDepositLock();
     expect(lock).toEqual({
       args: "0x702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd8a900000014000000340000009d000000a50000003837aad0e28da55d366d62b7df9b1b0613c39c730c4c409b9722d4bed8cfa9266900000010000000300000003100000007521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec00134000000702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd80c1efcca2bcb65a532274f3ef24c044ef4ab6d73803a0900000000c002000000",
-      code_hash: "0x50704b84ecb4c4b12b43c7acb260ddd69171c21b4c0ba15f3c469b7d143f6f18",
-      hash_type: "type",
+      codeHash: "0x50704b84ecb4c4b12b43c7acb260ddd69171c21b4c0ba15f3c469b7d143f6f18",
+      hashType: "type",
     });
   });
   it("should deposit 2000 ckb ok when user balance is 2000", async () => {
@@ -95,7 +95,7 @@ describe("test light godwoken v1 deposit", () => {
       capacity: BI.from(2000).mul(BI.from(10).pow(8)).toHexString(),
     });
 
-    expect(tx.outputs.get(0)?.cell_output.capacity).toEqual(BI.from(2000).mul(BI.from(10).pow(8)).toHexString());
+    expect(tx.outputs.get(0)?.cellOutput.capacity).toEqual(BI.from(2000).mul(BI.from(10).pow(8)).toHexString());
     expect(outputCapacityOf(tx).toString()).toEqual("2000");
   });
   it("should deposit 2000 ckb fail when user balance is 1999", async () => {
@@ -159,7 +159,7 @@ describe("test light godwoken v1 deposit", () => {
       capacity: BI.from(2000).mul(BI.from(10).pow(8)).toHexString(),
     });
 
-    expect(tx.outputs.get(0)?.cell_output.capacity).toEqual(BI.from(2000).mul(BI.from(10).pow(8)).toHexString());
+    expect(tx.outputs.get(0)?.cellOutput.capacity).toEqual(BI.from(2000).mul(BI.from(10).pow(8)).toHexString());
     expect(outputCapacityOf(tx).toString()).toEqual("2000");
   });
   it("should deposit 2000 ckb fail when user balance is 1999", async () => {

--- a/packages/light-godwoken/src/__tests__/utils.ts
+++ b/packages/light-godwoken/src/__tests__/utils.ts
@@ -1,4 +1,5 @@
-import { Cell, HexString, Script, HashType, BI, helpers, utils } from "@ckb-lumos/lumos";
+import { Cell, HexString, Script, HashType, BI, helpers } from "@ckb-lumos/lumos";
+import { number, bytes } from "@ckb-lumos/codec";
 import { LightGodwokenConfig } from "../config";
 import { RawWithdrawal } from "../schemas/codecV0";
 import { RawWithdrawalRequestV1 } from "../schemas/codecV1";
@@ -16,65 +17,65 @@ export const dummyScriptHash: HexString = `0x${"0".repeat(64)}`;
 
 export const randomScript = (byteLength: number): Script => {
   return {
-    code_hash: randomHexString(32),
-    hash_type: "type" as HashType,
+    codeHash: randomHexString(32),
+    hashType: "type" as HashType,
     args: randomHexString(byteLength),
   };
 };
 
 export const randomSudtTypeScriptWithoutArgs = (config: LightGodwokenConfig): Script => {
   return {
-    code_hash: config.layer1Config.SCRIPTS.sudt.code_hash,
-    hash_type: config.layer1Config.SCRIPTS.sudt.hash_type,
+    codeHash: config.layer1Config.SCRIPTS.sudt.codeHash,
+    hashType: config.layer1Config.SCRIPTS.sudt.hashType,
     args: "0x",
   };
 };
 
 export const randomSudtTypeScript = (config: LightGodwokenConfig): Script => {
   return {
-    code_hash: config.layer1Config.SCRIPTS.sudt.code_hash,
-    hash_type: config.layer1Config.SCRIPTS.sudt.hash_type,
+    codeHash: config.layer1Config.SCRIPTS.sudt.codeHash,
+    hashType: config.layer1Config.SCRIPTS.sudt.hashType,
     args: randomHexString(32),
   };
 };
 
 export const generateCellInput = (capacity: number, type?: Script, sudtData?: number) => {
-  const tx_hash = randomHexString(32);
+  const txHash = randomHexString(32);
   const lock = {
     args: randomHexString(20),
-    code_hash: randomHexString(32),
-    hash_type: "type" as HashType,
+    codeHash: randomHexString(32),
+    hashType: "type" as HashType,
   };
   const cellInput: Cell = {
-    block_number: "0x0",
-    out_point: {
+    blockNumber: "0x0",
+    outPoint: {
       index: "0x0",
-      tx_hash,
+      txHash,
     },
-    cell_output: {
+    cellOutput: {
       capacity: BI.from(capacity).mul(100000000).toHexString(),
       lock,
       type,
     },
-    data: sudtData ? utils.toBigUInt128LE(BI.from(sudtData).mul(1000000000000000000)) : "0x",
+    data: sudtData ? bytes.hexify(number.Uint128LE.pack(BI.from(sudtData).mul(1000000000000000000))) : "0x",
   };
   return cellInput;
 };
 
 export const outputCapacityOf = (tx: helpers.TransactionSkeletonType): BI => {
   const outputs = tx.outputs.toArray();
-  return outputs.reduce((sum, current) => sum.add(current.cell_output.capacity), BI.from(0)).div(100000000);
+  return outputs.reduce((sum, current) => sum.add(current.cellOutput.capacity), BI.from(0)).div(100000000);
 };
 export const inputCapacityOf = (tx: helpers.TransactionSkeletonType): BI => {
   const inputs = tx.inputs.toArray();
-  return inputs.reduce((sum, current) => sum.add(current.cell_output.capacity), BI.from(0)).div(100000000);
+  return inputs.reduce((sum, current) => sum.add(current.cellOutput.capacity), BI.from(0)).div(100000000);
 };
 export const outputSudtAmountOf = (tx: helpers.TransactionSkeletonType): BI => {
   const outputs = tx.outputs.toArray();
   return outputs
     .reduce((sum, current) => {
-      if (current.cell_output.type) {
-        return sum.add(utils.readBigUInt128LECompatible(current.data));
+      if (current.cellOutput.type) {
+        return sum.add(number.Uint128LE.unpack(current.data));
       } else {
         return sum;
       }

--- a/packages/light-godwoken/src/config/predefined/mainnet.ts
+++ b/packages/light-godwoken/src/config/predefined/mainnet.ts
@@ -1,29 +1,29 @@
 import { Layer1Config, LightGodwokenConfig, LightGodwokenConfigMap } from "../types";
-import { predefined } from "@ckb-lumos/config-manager";
+import { predefined, createConfig } from "@ckb-lumos/config-manager";
 import { predefinedTokens } from "../../tokens";
 
 export const MainnetLayer1Config: Layer1Config = {
   SCRIPTS: {
-    omni_lock: {
-      code_hash: "0x9f3aeaf2fc439549cbc870c653374943af96a0658bd6b51be8d8983183e6f52f",
-      hash_type: "type",
-      tx_hash: "0xaa8ab7e97ed6a268be5d7e26d63d115fa77230e51ae437fc532988dd0c3ce10a",
+    omniLock: {
+      codeHash: "0x9f3aeaf2fc439549cbc870c653374943af96a0658bd6b51be8d8983183e6f52f",
+      hashType: "type",
+      txHash: "0xaa8ab7e97ed6a268be5d7e26d63d115fa77230e51ae437fc532988dd0c3ce10a",
       index: "0x1",
-      dep_type: "code",
+      depType: "code",
     },
-    secp256k1_blake160: {
-      code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-      hash_type: "type",
-      tx_hash: "0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c",
+    secp256k1Blake160: {
+      codeHash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hashType: "type",
+      txHash: "0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c",
       index: "0x0",
-      dep_type: "dep_group",
+      depType: "depGroup",
     },
     sudt: {
-      code_hash: "0x5e7a36a77e68eecc013dfa2fe6a23f3b6c344b04005808694ae6dd45eea4cfd5",
-      hash_type: "type",
-      tx_hash: "0xc7813f6a415144643970c2e88e0bb6ca6a8edc5dd7c1022746f628284a9936d5",
+      codeHash: "0x5e7a36a77e68eecc013dfa2fe6a23f3b6c344b04005808694ae6dd45eea4cfd5",
+      hashType: "type",
+      txHash: "0xc7813f6a415144643970c2e88e0bb6ca6a8edc5dd7c1022746f628284a9936d5",
       index: "0x0",
-      dep_type: "code",
+      depType: "code",
     },
   },
   CKB_INDEXER_URL: "https://mainnet.ckb.dev/indexer",
@@ -31,41 +31,54 @@ export const MainnetLayer1Config: Layer1Config = {
   SCANNER_URL: "https://explorer.nervos.org",
 };
 
+export const MainnetLumosConfig = createConfig({
+  ...predefined.LINA,
+  SCRIPTS: {
+    ...predefined.LINA.SCRIPTS,
+    OMNILOCK: {
+      ...predefined.LINA.SCRIPTS.OMNILOCK,
+      CODE_HASH: MainnetLayer1Config.SCRIPTS.omniLock.codeHash,
+      TX_HASH: MainnetLayer1Config.SCRIPTS.omniLock.txHash,
+      INDEX: MainnetLayer1Config.SCRIPTS.omniLock.index,
+    },
+  },
+});
+
 // https://github.com/nervosnetwork/godwoken-info/blob/69175dff51fb63665abff7cc9640af5bf3409fea/mainnet_v0/config/scripts-result.json
 export const MainnetLayer2ConfigV0: LightGodwokenConfig = {
-  lumosConfig: predefined.LINA,
+  lumosConfig: MainnetLumosConfig,
   layer1Config: MainnetLayer1Config,
   layer2Config: {
     SCRIPTS: {
-      deposit_lock: {
-        script_type_hash: "0xe24164e2204f998b088920405dece3dcfd5c1fbcb23aecfce4b3d3edf1488897",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0x23fe9d6410c93b49039a9efa3b1549ff18772c03919bc6f2aa91643c4caa01ba",
+      depositLock: {
+        scriptTypeHash: "0xe24164e2204f998b088920405dece3dcfd5c1fbcb23aecfce4b3d3edf1488897",
+        cellDep: {
+          outPoint: {
+            txHash: "0x23fe9d6410c93b49039a9efa3b1549ff18772c03919bc6f2aa91643c4caa01ba",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      withdrawal_lock: {
-        script_type_hash: "0xf1717ee388b181fcb14352055c00b7ea7cd7c27350ffd1a2dd231e059dde2fed",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0x342dc7b96e663393fa606f05ae1ad8504fa776436d552677356b1023bb174beb",
+      withdrawalLock: {
+        scriptTypeHash: "0xf1717ee388b181fcb14352055c00b7ea7cd7c27350ffd1a2dd231e059dde2fed",
+        cellDep: {
+          outPoint: {
+            txHash: "0x342dc7b96e663393fa606f05ae1ad8504fa776436d552677356b1023bb174beb",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      eth_account_lock: {
-        script_type_hash: "0x1563080d175bf8ddd44a48e850cecf0c0b4575835756eb5ffd53ad830931b9f9",
+      ethAccountLock: {
+        scriptTypeHash: "0x1563080d175bf8ddd44a48e850cecf0c0b4575835756eb5ffd53ad830931b9f9",
       },
     },
     ROLLUP_CONFIG: {
-      rollup_type_hash: "0x40d73f0d3c561fcaae330eabc030d8d96a9d0af36d0c5114883658a350cb9e3b",
-      rollup_type_script: {
-        code_hash: "0xa9267ff5a16f38aa9382608eb9022883a78e6a40855107bb59f8406cce00e981",
-        hash_type: "type",
+      rollupTypeHash: "0x40d73f0d3c561fcaae330eabc030d8d96a9d0af36d0c5114883658a350cb9e3b",
+      rollupTypeScript: {
+        codeHash: "0xa9267ff5a16f38aa9382608eb9022883a78e6a40855107bb59f8406cce00e981",
+        hashType: "type",
         args: "0x2d8d67c8d73453c1a6d6d600e491b303910802e0cc90a709da9b15d26c5c48b3",
       },
     },
@@ -84,39 +97,39 @@ export const MainnetLayer2ConfigV0: LightGodwokenConfig = {
 
 // https://github.com/nervosnetwork/godwoken-info/blob/69175dff51fb63665abff7cc9640af5bf3409fea/mainnet_v1/scripts-deploy-result.json
 export const MainnetLayer2ConfigV1: LightGodwokenConfig = {
-  lumosConfig: predefined.LINA,
+  lumosConfig: MainnetLumosConfig,
   layer1Config: MainnetLayer1Config,
   layer2Config: {
     SCRIPTS: {
-      deposit_lock: {
-        script_type_hash: "0xff602581f07667eef54232cce850cbca2c418b3418611c132fca849d1edcd775",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0x61e576a7e5d2398ecc5b1a969d1af0142c87db0996c2f6fce41bf28f68d805b2",
+      depositLock: {
+        scriptTypeHash: "0xff602581f07667eef54232cce850cbca2c418b3418611c132fca849d1edcd775",
+        cellDep: {
+          outPoint: {
+            txHash: "0x61e576a7e5d2398ecc5b1a969d1af0142c87db0996c2f6fce41bf28f68d805b2",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      withdrawal_lock: {
-        script_type_hash: "0x3714af858b8b82b2bb8f13d51f3cffede2dd8d352a6938334bb79e6b845e3658",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0xe6389b5cf63eec1e2592e930414bc43f92508e529bdd5f5a07fa1dd140f4f20a",
+      withdrawalLock: {
+        scriptTypeHash: "0x3714af858b8b82b2bb8f13d51f3cffede2dd8d352a6938334bb79e6b845e3658",
+        cellDep: {
+          outPoint: {
+            txHash: "0xe6389b5cf63eec1e2592e930414bc43f92508e529bdd5f5a07fa1dd140f4f20a",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      eth_account_lock: {
-        script_type_hash: "0x096df264f38fff07f3acd318995abc2c71ae0e504036fe32bc38d5b6037364d4",
+      ethAccountLock: {
+        scriptTypeHash: "0x096df264f38fff07f3acd318995abc2c71ae0e504036fe32bc38d5b6037364d4",
       },
     },
     ROLLUP_CONFIG: {
-      rollup_type_hash: "0x1ca35cb5fda4bd542e71d94a6d5f4c0d255d6d6fba73c41cf45d2693e59b3072",
-      rollup_type_script: {
-        code_hash: "0xfef1d086d9f74d143c60bf03bd04bab29200dbf484c801c72774f2056d4c6718",
-        hash_type: "type",
+      rollupTypeHash: "0x1ca35cb5fda4bd542e71d94a6d5f4c0d255d6d6fba73c41cf45d2693e59b3072",
+      rollupTypeScript: {
+        codeHash: "0xfef1d086d9f74d143c60bf03bd04bab29200dbf484c801c72774f2056d4c6718",
+        hashType: "type",
         args: "0xab21bfe2bf85927bb42faaf3006a355222e24d5ea1d4dec0e62f53a8e0c04690",
       },
     },

--- a/packages/light-godwoken/src/config/predefined/testnet.ts
+++ b/packages/light-godwoken/src/config/predefined/testnet.ts
@@ -1,29 +1,29 @@
 import { Layer1Config, LightGodwokenConfig, LightGodwokenConfigMap } from "../types";
-import { predefined } from "@ckb-lumos/config-manager";
+import { predefined, createConfig } from "@ckb-lumos/config-manager";
 import { predefinedTokens } from "../../tokens";
 
 export const TestnetLayer1Config: Layer1Config = {
   SCRIPTS: {
-    omni_lock: {
-      code_hash: "0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e",
-      hash_type: "type",
-      tx_hash: "0x9154df4f7336402114d04495175b37390ce86a4906d2d4001cf02c3e6d97f39c",
+    omniLock: {
+      codeHash: "0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e",
+      hashType: "type",
+      txHash: "0x9154df4f7336402114d04495175b37390ce86a4906d2d4001cf02c3e6d97f39c",
       index: "0x0",
-      dep_type: "code",
+      depType: "code",
     },
-    secp256k1_blake160: {
-      code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-      hash_type: "type",
-      tx_hash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
+    secp256k1Blake160: {
+      codeHash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hashType: "type",
+      txHash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
       index: "0x0",
-      dep_type: "dep_group",
+      depType: "depGroup",
     },
     sudt: {
-      code_hash: "0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4",
-      hash_type: "type",
-      tx_hash: "0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769",
+      codeHash: "0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4",
+      hashType: "type",
+      txHash: "0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769",
       index: "0x0",
-      dep_type: "code",
+      depType: "code",
     },
   },
   CKB_INDEXER_URL: "https://testnet.ckb.dev/indexer",
@@ -31,41 +31,54 @@ export const TestnetLayer1Config: Layer1Config = {
   SCANNER_URL: "https://pudge.explorer.nervos.org",
 };
 
+export const TestnetLumosConfig = createConfig({
+  ...predefined.AGGRON4,
+  SCRIPTS: {
+    ...predefined.AGGRON4.SCRIPTS,
+    OMNILOCK: {
+      ...predefined.AGGRON4.SCRIPTS.OMNILOCK,
+      CODE_HASH: TestnetLayer1Config.SCRIPTS.omniLock.codeHash,
+      TX_HASH: TestnetLayer1Config.SCRIPTS.omniLock.txHash,
+      INDEX: TestnetLayer1Config.SCRIPTS.omniLock.index,
+    },
+  },
+});
+
 // https://github.com/nervosnetwork/godwoken-info/blob/69175dff51fb63665abff7cc9640af5bf3409fea/testnet_v0/config/scripts-deploy-result.json
 export const TestnetLayer2ConfigV0: LightGodwokenConfig = {
-  lumosConfig: predefined.AGGRON4,
+  lumosConfig: TestnetLumosConfig,
   layer1Config: TestnetLayer1Config,
   layer2Config: {
     SCRIPTS: {
-      deposit_lock: {
-        script_type_hash: "0x5a2506bb68d81a11dcadad4cb7eae62a17c43c619fe47ac8037bc8ce2dd90360",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0x97614145cdec9ba924001c11cd49f1c424927437b40ed3ca3b82fff358f2e3de",
+      depositLock: {
+        scriptTypeHash: "0x5a2506bb68d81a11dcadad4cb7eae62a17c43c619fe47ac8037bc8ce2dd90360",
+        cellDep: {
+          outPoint: {
+            txHash: "0x97614145cdec9ba924001c11cd49f1c424927437b40ed3ca3b82fff358f2e3de",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      withdrawal_lock: {
-        script_type_hash: "0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0xa8c2fe2aaaf405b2b1fd33dd63adc4c514a3d1f6dd1a64244489ad75c51a5d14",
+      withdrawalLock: {
+        scriptTypeHash: "0x170ef156e9f6132dbca6069dfd3e436f7d91c29d3ac7332c4b33e633b6a299b5",
+        cellDep: {
+          outPoint: {
+            txHash: "0xa8c2fe2aaaf405b2b1fd33dd63adc4c514a3d1f6dd1a64244489ad75c51a5d14",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      eth_account_lock: {
-        script_type_hash: "0xdeec13a7b8e100579541384ccaf4b5223733e4a5483c3aec95ddc4c1d5ea5b22",
+      ethAccountLock: {
+        scriptTypeHash: "0xdeec13a7b8e100579541384ccaf4b5223733e4a5483c3aec95ddc4c1d5ea5b22",
       },
     },
     ROLLUP_CONFIG: {
-      rollup_type_hash: "0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6a",
-      rollup_type_script: {
-        code_hash: "0x5c365147bb6c40e817a2a53e0dec3661f7390cc77f0c02db138303177b12e9fb",
-        hash_type: "type",
+      rollupTypeHash: "0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6a",
+      rollupTypeScript: {
+        codeHash: "0x5c365147bb6c40e817a2a53e0dec3661f7390cc77f0c02db138303177b12e9fb",
+        hashType: "type",
         args: "0x213743d13048e9f36728c547ab736023a7426e15a3d7d1c82f43ec3b5f266df2",
       },
     },
@@ -83,39 +96,39 @@ export const TestnetLayer2ConfigV0: LightGodwokenConfig = {
 
 // https://github.com/nervosnetwork/godwoken-info/blob/69175dff51fb63665abff7cc9640af5bf3409fea/testnet_v1_1/scripts-deploy-result.json
 export const TestnetLayer2ConfigV1: LightGodwokenConfig = {
-  lumosConfig: predefined.AGGRON4,
+  lumosConfig: TestnetLumosConfig,
   layer1Config: TestnetLayer1Config,
   layer2Config: {
     SCRIPTS: {
-      deposit_lock: {
-        script_type_hash: "0x50704b84ecb4c4b12b43c7acb260ddd69171c21b4c0ba15f3c469b7d143f6f18",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0x9caeec735f3cd2a60b9d12be59bb161f7c61ddab1ac22c4383a94c33ba6404a2",
+      depositLock: {
+        scriptTypeHash: "0x50704b84ecb4c4b12b43c7acb260ddd69171c21b4c0ba15f3c469b7d143f6f18",
+        cellDep: {
+          outPoint: {
+            txHash: "0x9caeec735f3cd2a60b9d12be59bb161f7c61ddab1ac22c4383a94c33ba6404a2",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      withdrawal_lock: {
-        script_type_hash: "0x06ae0706bb2d7997d66224741d3ec7c173dbb2854a6d2cf97088796b677269c6",
-        cell_dep: {
-          out_point: {
-            tx_hash: "0x9c607a9a75ea4699dd01b1c2a478002343998cac8346d2aa582f35b532bd2b93",
+      withdrawalLock: {
+        scriptTypeHash: "0x06ae0706bb2d7997d66224741d3ec7c173dbb2854a6d2cf97088796b677269c6",
+        cellDep: {
+          outPoint: {
+            txHash: "0x9c607a9a75ea4699dd01b1c2a478002343998cac8346d2aa582f35b532bd2b93",
             index: "0x0",
           },
-          dep_type: "code",
+          depType: "code",
         },
       },
-      eth_account_lock: {
-        script_type_hash: "0x07521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec0",
+      ethAccountLock: {
+        scriptTypeHash: "0x07521d0aa8e66ef441ebc31204d86bb23fc83e9edc58c19dbb1b0ebe64336ec0",
       },
     },
     ROLLUP_CONFIG: {
-      rollup_type_hash: "0x702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd8",
-      rollup_type_script: {
-        code_hash: "0x1e44736436b406f8e48a30dfbddcf044feb0c9eebfe63b0f81cb5bb727d84854",
-        hash_type: "type",
+      rollupTypeHash: "0x702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd8",
+      rollupTypeScript: {
+        codeHash: "0x1e44736436b406f8e48a30dfbddcf044feb0c9eebfe63b0f81cb5bb727d84854",
+        hashType: "type",
         args: "0x86c7429247beba7ddd6e4361bcdfc0510b0b644131e2afb7e486375249a01802",
       },
     },

--- a/packages/light-godwoken/src/config/types.ts
+++ b/packages/light-godwoken/src/config/types.ts
@@ -14,21 +14,21 @@ export enum GodwokenNetwork {
 
 export type Layer2Config = {
   SCRIPTS: {
-    deposit_lock: {
-      script_type_hash: Hash;
-      cell_dep: CellDep;
+    depositLock: {
+      scriptTypeHash: Hash;
+      cellDep: CellDep;
     };
-    withdrawal_lock: {
-      script_type_hash: Hash;
-      cell_dep: CellDep;
+    withdrawalLock: {
+      scriptTypeHash: Hash;
+      cellDep: CellDep;
     };
-    eth_account_lock: {
-      script_type_hash: Hash;
+    ethAccountLock: {
+      scriptTypeHash: Hash;
     };
   };
   ROLLUP_CONFIG: {
-    rollup_type_hash: Hash;
-    rollup_type_script: Script;
+    rollupTypeHash: Hash;
+    rollupTypeScript: Script;
   };
   GW_POLYJUICE_RPC_URL: string;
   SCANNER_URL: string;
@@ -40,19 +40,19 @@ export type Layer2Config = {
   MULTICALL_ADDRESS?: string;
 };
 
-export type ScriptType = {
-  code_hash: Hash;
-  hash_type: HashType;
-  tx_hash: Hash;
+export type Layer1ConfigScript = {
+  codeHash: Hash;
+  hashType: HashType;
+  txHash: Hash;
   index: Hexadecimal;
-  dep_type: DepType;
+  depType: DepType;
 };
 
 export type Layer1Config = {
   SCRIPTS: {
-    omni_lock: ScriptType;
-    secp256k1_blake160: ScriptType;
-    sudt: ScriptType;
+    omniLock: Layer1ConfigScript;
+    secp256k1Blake160: Layer1ConfigScript;
+    sudt: Layer1ConfigScript;
   };
   CKB_INDEXER_URL: string;
   CKB_RPC_URL: string;

--- a/packages/light-godwoken/src/config/utils.ts
+++ b/packages/light-godwoken/src/config/utils.ts
@@ -1,13 +1,13 @@
 import { CellDep } from "@ckb-lumos/lumos";
-import { ScriptType } from "./types";
+import { Layer1ConfigScript } from "./types";
 
-export function getCellDep(script: ScriptType): CellDep {
+export function getCellDep(script: Layer1ConfigScript): CellDep {
   return {
-    out_point: {
-      tx_hash: script.tx_hash,
+    outPoint: {
+      txHash: script.txHash,
       index: script.index,
     },
-    dep_type: script.dep_type,
+    depType: script.depType,
   };
 }
 

--- a/packages/light-godwoken/src/lightGodwokenType.ts
+++ b/packages/light-godwoken/src/lightGodwokenType.ts
@@ -148,7 +148,7 @@ export interface DepositPayload {
 }
 
 export interface PendingDepositTransaction {
-  tx_hash: Hash;
+  txHash: Hash;
 }
 
 type PromiseOr<T> = Promise<T> | T;

--- a/packages/light-godwoken/src/schemas/codecLayer1.ts
+++ b/packages/light-godwoken/src/schemas/codecLayer1.ts
@@ -1,4 +1,5 @@
-import { molecule, number, blockchain } from "@ckb-lumos/codec/";
+import { molecule, number } from "@ckb-lumos/codec";
+import { blockchain } from "@ckb-lumos/base";
 import { HexString } from "@ckb-lumos/lumos";
 
 const { table, option, vector, array } = molecule;

--- a/packages/light-godwoken/src/schemas/codecV0.ts
+++ b/packages/light-godwoken/src/schemas/codecV0.ts
@@ -1,10 +1,11 @@
-import { molecule, number, blockchain } from "@ckb-lumos/codec/";
+import { molecule, number } from "@ckb-lumos/codec";
 import { BI, HexString } from "@ckb-lumos/lumos";
+import { blockchain } from "@ckb-lumos/base";
 import { hashTypeCodec } from "./baseCodec";
 
 const { table, option, struct } = molecule;
-const { Bytes, Byte32 } = blockchain;
 const { Uint32, Uint128, Uint8, Uint64 } = number;
+const { Bytes, Byte32 } = blockchain;
 
 export type RawWithdrawal = {
   nonce: number;

--- a/packages/light-godwoken/src/schemas/codecV1.ts
+++ b/packages/light-godwoken/src/schemas/codecV1.ts
@@ -1,5 +1,6 @@
+import { blockchain } from "@ckb-lumos/base";
 import { BI, HexString } from "@ckb-lumos/lumos";
-import { molecule, number, blockchain, createObjectCodec, enhancePack } from "@ckb-lumos/codec";
+import { molecule, number, createObjectCodec, enhancePack } from "@ckb-lumos/codec";
 import { hashTypeCodec } from "./baseCodec";
 
 const { table, struct } = molecule;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1426,18 +1426,6 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ckb-lumos/base@0.17.0", "@ckb-lumos/base@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/base/-/base-0.17.0.tgz#4d6d6081947aae7bdea633c7de41f5a23bbeec04"
-  integrity sha512-Yb3/g9vNwS+O+xKgkypcoIhkNwBXbpmhWUZvxzH5iKdZik0gH92bfFH5geFx2w03EtgBkfy1jbveF48mz0Ia0Q==
-  dependencies:
-    "@ckb-lumos/bi" "0.17.0"
-    "@ckb-lumos/toolkit" "0.17.0"
-    "@types/lodash.isequal" "^4.5.5"
-    blake2b "^2.1.3"
-    js-xxhash "^1.0.4"
-    lodash.isequal "^4.5.0"
-
 "@ckb-lumos/base@0.18.0-rc6":
   version "0.18.0-rc6"
   resolved "https://registry.yarnpkg.com/@ckb-lumos/base/-/base-0.18.0-rc6.tgz#47fba5c619359e0715b191d806608f22bf96d52d"
@@ -1450,12 +1438,19 @@
     js-xxhash "^1.0.4"
     lodash.isequal "^4.5.0"
 
-"@ckb-lumos/bi@0.17.0", "@ckb-lumos/bi@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/bi/-/bi-0.17.0.tgz#65ab8300451b1a2f7105b0167f9bebe0c895ce09"
-  integrity sha512-MNLNVoX1jO4JoEkSvt8JZI48KkKjzbsEUt9JqAWMc3iNgJ7SIXXGX1Cv9YxY5Kxwsq64Cs6O4nm5iEE4wH6vlA==
+"@ckb-lumos/base@0.20.0-alpha.1", "@ckb-lumos/base@^0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/base/-/base-0.20.0-alpha.1.tgz#7d930b1537ac1eb3ab4561dc62e39917d9060053"
+  integrity sha512-KjiZBF2FfoRWsPFMWaUmzFcdFDI33oHd9Gruesl/9AQ+Y2yCWhV5mPTiIGbDaQuaCbKBb1MPAVmOyaI5i7e02g==
   dependencies:
-    jsbi "^4.1.0"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
+    "@ckb-lumos/codec" "0.20.0-alpha.1"
+    "@ckb-lumos/toolkit" "0.20.0-alpha.1"
+    "@types/blake2b" "^2.1.0"
+    "@types/lodash.isequal" "^4.5.5"
+    blake2b "^2.1.3"
+    js-xxhash "^1.0.4"
+    lodash.isequal "^4.5.0"
 
 "@ckb-lumos/bi@0.18.0-rc6":
   version "0.18.0-rc6"
@@ -1464,105 +1459,115 @@
   dependencies:
     jsbi "^4.1.0"
 
-"@ckb-lumos/ckb-indexer@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.17.0.tgz#e6ce46ff09382c50c0008e0c9e1c92a9297f12f0"
-  integrity sha512-Cf8m7wovVUZktKwgCdgVx2KE9tTbYoYYvzy9TZhosgrkQ9YiYc0WoeIDnTv2JiUWB1AmVVKN4lgqIHnZ2RSGmQ==
+"@ckb-lumos/bi@0.20.0-alpha.1", "@ckb-lumos/bi@^0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/bi/-/bi-0.20.0-alpha.1.tgz#dd4715c5fdfdee236f602d013d871c74ea7e7b9e"
+  integrity sha512-2i20NvOBXcsamUo4aBjaJ/HeAOgCPCqBXnGbqGAVX/FKaqS7cIIvji3JRjdU6ct8bqPuBInYseL9umJWJR0TsA==
   dependencies:
-    "@ckb-lumos/base" "0.17.0"
-    "@ckb-lumos/bi" "0.17.0"
-    "@ckb-lumos/rpc" "0.17.0"
-    "@ckb-lumos/toolkit" "0.17.0"
+    jsbi "^4.1.0"
+
+"@ckb-lumos/ckb-indexer@0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/ckb-indexer/-/ckb-indexer-0.20.0-alpha.1.tgz#c637f9fbff0ac20acf10ba28b795d134d04ff135"
+  integrity sha512-1WAHCMSBabrr8cbou6gRMivx85na6gOBvQC5SYIozleGoCfKfhiTW8ZnBNT0A8pi86RVILdEqGGiqaALDdZheA==
+  dependencies:
+    "@ckb-lumos/base" "0.20.0-alpha.1"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
+    "@ckb-lumos/rpc" "0.20.0-alpha.1"
+    "@ckb-lumos/toolkit" "0.20.0-alpha.1"
     cross-fetch "^3.1.5"
     events "^3.3.0"
 
-"@ckb-lumos/codec@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/codec/-/codec-0.17.0.tgz#915be1de4c0858fee14e491788a6b835277e9c23"
-  integrity sha512-9/gpI2rFqvUI3f7YXYhYuRRP52/rdeDUilTeafjUPuFZ7UwLg8Lh/f3oOl6h3ck3hyPu0nDsz3Qf/36U4w17Ew==
+"@ckb-lumos/codec@0.20.0-alpha.1", "@ckb-lumos/codec@^0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/codec/-/codec-0.20.0-alpha.1.tgz#4ce6e8fef818baa2d452e5ca0621c2984a37606e"
+  integrity sha512-Jgp6bNdPbQtLqn8BvodhQ/kMFJ2A3UnkF/rDgWPNKX7wOrtkkcoEBSEVynHHrFXsihNq1aiHt6R7nbKx/dPTwQ==
   dependencies:
-    "@ckb-lumos/bi" "0.17.0"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
 
-"@ckb-lumos/common-scripts@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/common-scripts/-/common-scripts-0.17.0.tgz#8e2fb53839001c862b7aa83a9f640ac75cf216ff"
-  integrity sha512-usmckI5tIvRQJkrdzZOr5mAlTYsRg+ogyexw8/xmkrkq0a+Dj2v7tGILC7y75eiVj9B4et8/1JO07+Ru0xCkOw==
+"@ckb-lumos/common-scripts@0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/common-scripts/-/common-scripts-0.20.0-alpha.1.tgz#6fb5fc6fe3dfa887f42249c5f68aaf2288fe4374"
+  integrity sha512-ruiZJOfh3PPNjKdJBvn9KsMgRFi6c8lAlAu1uCvZxmd+J6AtLYHyPeL6K04MnTSy3SPxvGgh38bkVpcQ5qzSiA==
   dependencies:
-    "@ckb-lumos/base" "0.17.0"
-    "@ckb-lumos/bi" "0.17.0"
-    "@ckb-lumos/config-manager" "0.17.0"
-    "@ckb-lumos/helpers" "0.17.0"
-    "@ckb-lumos/rpc" "0.17.0"
-    "@ckb-lumos/toolkit" "0.17.0"
+    "@ckb-lumos/base" "0.20.0-alpha.1"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
+    "@ckb-lumos/codec" "0.20.0-alpha.1"
+    "@ckb-lumos/config-manager" "0.20.0-alpha.1"
+    "@ckb-lumos/helpers" "0.20.0-alpha.1"
+    "@ckb-lumos/rpc" "0.20.0-alpha.1"
+    "@ckb-lumos/toolkit" "0.20.0-alpha.1"
     immutable "^4.0.0-rc.12"
 
-"@ckb-lumos/config-manager@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/config-manager/-/config-manager-0.17.0.tgz#233f45e401e5a6479a2dcc7c8947ff0ebc5cee7e"
-  integrity sha512-I8eCV8bAyE/v+uGcu0YOB43v4ZUwTY9dHpE67gW5VJzloXFdIUedpgMpeySA/rmicZ3yhzoh2WhE5CmqGkDU5Q==
+"@ckb-lumos/config-manager@0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/config-manager/-/config-manager-0.20.0-alpha.1.tgz#23930d6ca47a3e2ffbd37b1f243aa5504c27c6fc"
+  integrity sha512-q+7X4aHXe+y7RcVzybsvZ6U/GGtBnBt5VVMyZAllSGU/vs70jjotII+j3LyW7eT6VD2GTukrR9yGsLpOBz/5Hw==
   dependencies:
-    "@ckb-lumos/base" "0.17.0"
-    "@ckb-lumos/bi" "0.17.0"
+    "@ckb-lumos/base" "0.20.0-alpha.1"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
+    "@ckb-lumos/codec" "0.20.0-alpha.1"
     "@types/deep-freeze-strict" "^1.1.0"
     deep-freeze-strict "^1.1.1"
 
-"@ckb-lumos/hd@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/hd/-/hd-0.17.0.tgz#e35c6c59b4804d4f299b2a13a0c00ab2e620dc8b"
-  integrity sha512-epUGWfrAVv5a6Ilu8nC4NwW8Riza/qTBHbaYAX8D3r161H9JlO4i7XTysTpWDCuZKJ/Aa9JelsgcMinqbf5ZpA==
+"@ckb-lumos/hd@0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/hd/-/hd-0.20.0-alpha.1.tgz#15152f904adfec9b1f2c81db1d7dfb40c796e84b"
+  integrity sha512-NQcTH3TweKOdFlH7r0fWXHgaoNdZXz44hPJgH9DFOBJgc1ZilLUS17bh4dvsegI3O/IVsusOU4KvWeZP/DLGKw==
   dependencies:
-    "@ckb-lumos/base" "0.17.0"
-    "@ckb-lumos/bi" "0.17.0"
+    "@ckb-lumos/base" "0.20.0-alpha.1"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
     bn.js "^5.1.3"
     elliptic "^6.5.4"
     sha3 "^2.1.3"
     uuid "^8.3.0"
 
-"@ckb-lumos/helpers@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/helpers/-/helpers-0.17.0.tgz#2f43e5d11b9d54c1dab237d3ed3af86a1ea28c07"
-  integrity sha512-sfZsTSLrLJ1HGOwBCcYJrG4tq4LllOzbw42o6MObg1DNvzKAK4A/lu2zMi61sKMVdNB5I0zgqT1JtKurzw5jcw==
+"@ckb-lumos/helpers@0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/helpers/-/helpers-0.20.0-alpha.1.tgz#ab91ccf69b6e9e248944cf6987f0dbfcae15e0e3"
+  integrity sha512-Y0Se0RBAOa9xhtn+KLZj61xm346/3eTcc1XtoOyIv+sjd63+JZ4qgCItsy/mr8iqHOCsg0xpw2b+yoTiHv/5AQ==
   dependencies:
-    "@ckb-lumos/base" "0.17.0"
-    "@ckb-lumos/bi" "0.17.0"
-    "@ckb-lumos/config-manager" "0.17.0"
-    "@ckb-lumos/toolkit" "0.17.0"
+    "@ckb-lumos/base" "0.20.0-alpha.1"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
+    "@ckb-lumos/config-manager" "0.20.0-alpha.1"
+    "@ckb-lumos/toolkit" "0.20.0-alpha.1"
     bech32 "^2.0.0"
     immutable "^4.0.0-rc.12"
 
-"@ckb-lumos/lumos@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/lumos/-/lumos-0.17.0.tgz#ef291d8bed86e6117d35fc77b4a6445384ca7fd7"
-  integrity sha512-J6HFcZ7C+Mi9SoTTleseJhcaZvmiLD6tlCz5vKw0wbfbpMr3io6tmAKcJ/ZHV51x+QoaeuBUdpQOnxhz6AhxuA==
+"@ckb-lumos/lumos@^0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/lumos/-/lumos-0.20.0-alpha.1.tgz#916281dac504cba0fee25541a59d63a582409e57"
+  integrity sha512-3jjnUVusP+Vm6wYuoILZiyUgoGpC371FStVbqBKE7pQ8hOvrXknLcPfTgCFMiuINZMj6H+t/PHhIuiRwSjOC4w==
   dependencies:
-    "@ckb-lumos/base" "0.17.0"
-    "@ckb-lumos/bi" "0.17.0"
-    "@ckb-lumos/ckb-indexer" "0.17.0"
-    "@ckb-lumos/common-scripts" "0.17.0"
-    "@ckb-lumos/config-manager" "0.17.0"
-    "@ckb-lumos/hd" "0.17.0"
-    "@ckb-lumos/helpers" "0.17.0"
-    "@ckb-lumos/rpc" "0.17.0"
-    "@ckb-lumos/toolkit" "0.17.0"
+    "@ckb-lumos/base" "0.20.0-alpha.1"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
+    "@ckb-lumos/ckb-indexer" "0.20.0-alpha.1"
+    "@ckb-lumos/common-scripts" "0.20.0-alpha.1"
+    "@ckb-lumos/config-manager" "0.20.0-alpha.1"
+    "@ckb-lumos/hd" "0.20.0-alpha.1"
+    "@ckb-lumos/helpers" "0.20.0-alpha.1"
+    "@ckb-lumos/rpc" "0.20.0-alpha.1"
+    "@ckb-lumos/toolkit" "0.20.0-alpha.1"
 
-"@ckb-lumos/rpc@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/rpc/-/rpc-0.17.0.tgz#b59cc6003e2029aadecfd946cf4e95a14d9ea13a"
-  integrity sha512-UuR4LDo8sFOebSMqeai9KuF/DHl731dLYRuXRMURNx8QXVnHo2PXGtzCJs+F0DrJg0WECcAEAkJKh2/0ZDTJWw==
+"@ckb-lumos/rpc@0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/rpc/-/rpc-0.20.0-alpha.1.tgz#37e632659665057c74424f6b0290f322c0885c57"
+  integrity sha512-a3u6BHdPerzSeaBptY9Yt7yhmF7ie5k7yW9wARcfh4CXc3i5x6C1vULIiNYVo98Kxa+OjtRcvUx++77T+N4cMg==
   dependencies:
-    "@ckb-lumos/base" "0.17.0"
-    "@ckb-lumos/bi" "0.17.0"
-    "@ckb-lumos/toolkit" "0.17.0"
-
-"@ckb-lumos/toolkit@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ckb-lumos/toolkit/-/toolkit-0.17.0.tgz#4df2bb822b3d8de3deeee02aa8a658017efffe5c"
-  integrity sha512-y9MrQMjH3qVj6bZCnps5aydu1wAwM4u/cv0c4o2AqxHNq9axIt5hZmI8Z9hswDctcyeWll1aLpYamy3Wt+wz4Q==
+    "@ckb-lumos/base" "0.20.0-alpha.1"
+    "@ckb-lumos/bi" "0.20.0-alpha.1"
+    axios "0.21.4"
+    tslib "2.3.1"
 
 "@ckb-lumos/toolkit@0.18.0-rc6":
   version "0.18.0-rc6"
   resolved "https://registry.yarnpkg.com/@ckb-lumos/toolkit/-/toolkit-0.18.0-rc6.tgz#e11849aab895bd152b953ce0cd25101970111d06"
   integrity sha512-s4VweBERcelCupeaAZlspaAXJFZH9BGlLkPbYUDbVuNz7Fmss39FqKQOJohS9rBqLkeINxO4BmuSjdCaqnuDfg==
+
+"@ckb-lumos/toolkit@0.20.0-alpha.1":
+  version "0.20.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ckb-lumos/toolkit/-/toolkit-0.20.0-alpha.1.tgz#a29b03f4f363c3c58aa2d95af743d4b62ebf963b"
+  integrity sha512-JwQGRMNuZpPW6y8Z2JFLy1jyCfWVC5iKU+zP0yEXfWNPH/tWI7xOzBNnRuuYlicbweKlRxp7wlWkGp5O2jb2OQ==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -4356,6 +4361,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/blake2b@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/blake2b/-/blake2b-2.1.0.tgz#d906320255d84f9c05fc6f3a28db81c952ee989b"
+  integrity sha512-Mv8N0qtdb72iW1XJR/4Yp01frtibnv8BpFUZDROnzd7hVEX4cEN/xHgU2ZfsnOnTDt+fHJVc0uRIWcNz6uIB2A==
+
 "@types/bn.js@^4.11.3":
   version "4.11.6"
   resolved "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz"
@@ -5658,6 +5668,13 @@ axe-core@^4.3.5:
   version "4.3.5"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz"
   integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
+
+axios@0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
 
 axios@^0.27.2:
   version "0.27.2"
@@ -9590,6 +9607,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.9:
   version "1.15.1"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
+follow-redirects@^1.14.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -18462,15 +18484,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2.3.1, tslib@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.3:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@^2.1.0, tslib@^2.3.0:
   version "2.4.0"


### PR DESCRIPTION
### Changes
The version of `ckb-lumos` we depend on is too old, causing some of our features to break. Fixing them by:
- Migrate ckb-lumos to the latest version
- Lock the version of omni_lock in ckb-lumos
- Replace `CkbIndexer.tip()` calls with `CkbRpc.getIndexerTip()`

### Related issues/pull_requests
- resolve #249 
- close #182

### Migration guides
- https://lumos-website.vercel.app/migrations/migrate-to-v0.19
- https://lumos-website.vercel.app/migrations/migrate-to-v0.20