### PR TITLE
chore: add .env.development

### DIFF
--- a/apps/godwoken-bridge/.env.development
+++ b/apps/godwoken-bridge/.env.development
@@ -1,0 +1,9 @@
+SKIP_PREFLIGHT_CHECK=true
+PORT=4001
+
+REACT_APP_VERSION=$npm_package_version
+REACT_APP_NAME=$npm_package_name
+REACT_APP_NETWORK=testnet
+
+# This private-key is for testing only, please make sure not to use it on other networks
+REACT_APP_L1_TEST_TOKEN_ISSUER_PRIVATE_KEY=0xb60bf0787fa97c52bb62d41131757954d5bda2f2054fb0c5efa172fa6b945296


### PR DESCRIPTION
Adds a `.env.development`  file to godwoken-bridge, so new developers can run the app without extra help.
And if new developers needs a different env, they can just duplicate the `.env.development` file and name the new file `.env.development.local`, git will not include it.