### PR TITLE
fix: get TTKN appears duplicated transaction

### DIFF
--- a/apps/godwoken-bridge/src/components/ClaimSudt/index.tsx
+++ b/apps/godwoken-bridge/src/components/ClaimSudt/index.tsx
@@ -35,7 +35,7 @@ export const ClaimSudt: React.FC = () => {
         // Pool rejected duplicated transaction
         // If it appears in multiple places, consider turning it into a common error
         if (errObj.code === -1107) {
-          notification.error({message: "The transaction is already in the pool. Please try again later"});
+          notification.error({ message: "The transaction is already in the pool. Please try again later" });
           return;
         }
       }

--- a/apps/godwoken-bridge/src/components/ClaimSudt/index.tsx
+++ b/apps/godwoken-bridge/src/components/ClaimSudt/index.tsx
@@ -3,7 +3,6 @@ import { notification } from "antd";
 import { claimUSDC } from "./sudtFaucet";
 import { useLightGodwoken } from "../../hooks/useLightGodwoken";
 import { LightGodwokenNotFoundError, NotEnoughCapacityError } from "light-godwoken";
-
 export const ClaimSudt: React.FC = () => {
   const lightGodwoken = useLightGodwoken();
 
@@ -28,9 +27,20 @@ export const ClaimSudt: React.FC = () => {
         setTimeout(() => {
           window.open("https://faucet.nervos.org", "_blank");
         }, 3000);
-      } else {
-        throw error;
+        return;
       }
+
+      if (error instanceof Error) {
+        const errObj = JSON.parse(error.message);
+        // Pool rejected duplicated transaction
+        // If it appears in multiple places, consider turning it into a common error
+        if (errObj.code === -1107) {
+          notification.error({message: "The transaction is already in the pool. Please try again later"});
+          return;
+        }
+      }
+
+      throw error;
     }
   };
   return <div onClick={claimSudt}>Get 1,000 Test Token(TTKN) on L1</div>;


### PR DESCRIPTION
### Discribe
Currently, there is no better solution to avoid `double spend` when constructing transactions, so use the simplest error prompt for processing

### Related problem
- fix #197 