### PR TITLE
feat: refactor the Withdrawal Pending List

### DIFF
--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -1,12 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LightGodwokenV1 } from "light-godwoken";
 import { AxiosError } from "axios";
 import styled from "styled-components";
-import Tooltip from "antd/lib/tooltip";
-import QuestionCircleOutlined from "@ant-design/icons/lib/icons/QuestionCircleOutlined";
 import { LinkList, Tab } from "../../style/common";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
-import { useInfiniteScroll } from "ahooks";
+import { useDebounceEffect, useDeepCompareEffect, useInfiniteScroll } from "ahooks";
 import { useLightGodwoken } from "../../hooks/useLightGodwoken";
 import { Placeholder } from "../Placeholder";
 import { L1TxHistoryInterface } from "../../hooks/useL1TxHistory";
@@ -16,6 +14,7 @@ import { Empty } from "../Container/Empty";
 const WithdrawalListDiv = styled.div`
   border-bottom-left-radius: 24px;
   border-bottom-right-radius: 24px;
+
   .list {
     max-height: 500px;
     min-height: 50px;
@@ -23,28 +22,39 @@ const WithdrawalListDiv = styled.div`
   }
 `;
 
-interface Props {
-  txHistory: L1TxHistoryInterface[];
-  updateTxWithStatus: (txHash: string, status: string) => void;
+interface WithdrawalHistoryType {
+  remainingBlockNumber?: number;
+  sudt_script_hash?: string;
+  withdrawalBlockNumber?: number;
+  status: string;
+  layer1TxHash?: string;
+  txHash: string;
+  amount: string;
+  capacity: string;
 }
 
-export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) => {
+interface Props {
+  txHistory: L1TxHistoryInterface[];
+  removeTxWithTxHashes: (txHash: string[]) => void;
+}
+
+export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory, removeTxWithTxHashes }) => {
   const params = useParams();
   const navigate = useNavigate();
   const isPending = params.status === "pending";
   const isCompleted = params.status === "completed";
+  const lightGodwoken = useLightGodwoken();
+  const [pendingHistory, setPendingHistory] = useState<WithdrawalHistoryType[] | undefined>(undefined);
+
   function navigateStatus(targetStatus: "pending" | "completed") {
     navigate(`/${params.version}/withdrawal/${targetStatus}`);
   }
-
-  const lightGodwoken = useLightGodwoken();
 
   const listRef = useRef<HTMLDivElement>(null);
   const withdrawalHistory = useInfiniteScroll(
     async (data) => {
       const page = data?.page ? data.page + 1 : 1;
       const list = await getWithdrawalHistories(lightGodwoken as LightGodwokenV1, page);
-      console.log("list", list);
 
       return {
         list,
@@ -77,18 +87,66 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
     return withdrawalHistory?.data?.list || [];
   }, [withdrawalHistory]);
   const pendingList = useMemo(() => {
-    return withdrawalList?.filter((history) => ["pending", "available"].includes(history.status)) || [];
-  }, [withdrawalList]);
+    return pendingHistory || [];
+  }, [pendingHistory]);
+  const hasL2Pending = useMemo(() => {
+    return pendingList.filter((item) => item.status === "l2Pending").length > 0;
+  }, [pendingList]);
   const completedList = useMemo(() => {
     return withdrawalList?.filter((history) => history.status === "succeed") || [];
   }, [withdrawalList]);
 
-  const displayLocalTxHistory = localTxHistory
-    .filter((history) => history.status === "l2Pending")
-    .map((history) => ({
-      ...history,
-      status: "l2Pending",
-    }));
+  const loadPendingHistory = useCallback(() => {
+    if (localTxHistory.length === 0) {
+      setPendingHistory([]);
+      return;
+    }
+    getPendingHistoriesByRPC(lightGodwoken as LightGodwokenV1, localTxHistory).then((list) => setPendingHistory(list));
+  }, [localTxHistory, lightGodwoken]);
+
+  useDebounceEffect(() => loadPendingHistory(), [localTxHistory]);
+
+  const removeLocalTxHistory = useCallback(() => {
+    if (pendingList.length === 0) return;
+    const removeHashes = [];
+    for (const item of pendingList) {
+      const index = completedList.findIndex(
+        (_) => _.layer1TxHash === item.layer1TxHash && ["succeed", "failed"].includes(_.status),
+      );
+      if (index >= 0) {
+        removeHashes.push(item.txHash);
+      }
+    }
+    removeTxWithTxHashes(removeHashes);
+  }, [completedList, pendingList, removeTxWithTxHashes]);
+
+  useDebounceEffect(() => removeLocalTxHistory(), [withdrawalHistory]);
+
+  const checkL2PendingTimer = useRef<NodeJS.Timeout>();
+  useDeepCompareEffect(() => {
+    if (checkL2PendingTimer.current) {
+      clearTimeout(checkL2PendingTimer.current);
+    }
+    if (hasL2Pending) {
+      loadPendingHistory();
+      checkL2PendingTimer.current = setInterval(() => {
+        loadPendingHistory();
+      }, 15000);
+    }
+    return () => {
+      if (checkL2PendingTimer.current) {
+        clearTimeout(checkL2PendingTimer.current);
+      }
+    };
+  }, [hasL2Pending]);
+
+  const onPendingClick = useCallback(() => {
+    if (isPending && pendingList.length > 0 && !hasL2Pending) {
+      loadPendingHistory();
+    }
+  }, [isPending, pendingList, hasL2Pending, loadPendingHistory]);
+
+  useDebounceEffect(() => onPendingClick(), [isPending]);
 
   const refreshTimer = useRef<NodeJS.Timeout>();
   const intervalReloadHistory = useCallback(() => {
@@ -101,7 +159,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
         reloadWithdrawalHistory();
         intervalReloadHistory();
       }
-    }, 60000);
+    }, 65000);
   }, [isPending, reloadWithdrawalHistory]);
   useEffect(() => {
     intervalReloadHistory();
@@ -116,7 +174,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
   if (!isPending && !isCompleted) {
     return <Navigate to={`/${params.version}/withdrawal/pending`} />;
   }
-  if (!lightGodwoken || !withdrawalHistory.data?.initialized) {
+  if (!lightGodwoken || pendingHistory === undefined) {
     return (
       <WithdrawalListDiv>
         <Placeholder />
@@ -128,10 +186,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
     <WithdrawalListDiv>
       <LinkList>
         <Tab className={isPending ? "active" : ""} onClick={() => navigateStatus("pending")}>
-          <Tooltip title="After a successful withdrawal transaction is sent, it usually comes up in the pending list within five minutes.">
-            Pending
-            <QuestionCircleOutlined style={{ marginLeft: 8, color: "#000000", height: "21px", lineHeight: "21px" }} />
-          </Tooltip>
+          Pending
         </Tab>
         <Tab className={isCompleted ? "active" : ""} onClick={() => navigateStatus("completed")}>
           Completed
@@ -139,10 +194,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
       </LinkList>
       {isPending && (
         <div className="list pending-list">
-          {pendingList.length + displayLocalTxHistory.length === 0 && <Empty>No pending withdrawals</Empty>}
-          {displayLocalTxHistory.map((withdraw, index) => (
-            <WithdrawalRequestCard {...withdraw} key={index}></WithdrawalRequestCard>
-          ))}
+          {pendingList.length === 0 && <Empty>No pending withdrawals</Empty>}
           {pendingList.map((withdraw, index) => (
             <WithdrawalRequestCard {...withdraw} key={index}></WithdrawalRequestCard>
           ))}
@@ -156,7 +208,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
           ))}
         </div>
       )}
-      {isLoading && <Placeholder />}
+      {isCompleted && isLoading && <Placeholder />}
     </WithdrawalListDiv>
   );
 };
@@ -181,4 +233,39 @@ async function getWithdrawalHistories(lightGodwoken: LightGodwokenV1, page: numb
 
     throw e;
   }
+}
+
+async function getPendingHistoriesByRPC(lightGodwoken: LightGodwokenV1, txHistory: L1TxHistoryInterface[]) {
+  if (txHistory.length === 0) return [];
+  const lastFinalizedBlockNumber = await lightGodwoken.provider.getLastFinalizedBlockNumber();
+  const promises: any[] = [];
+  for (const item of txHistory) {
+    promises.push(
+      new Promise(async (resolve) => {
+        let data: WithdrawalHistoryType = {
+          amount: item.amount,
+          capacity: item.capacity,
+          status: "l2Pending",
+          txHash: item.txHash,
+        };
+        try {
+          const result = (await lightGodwoken.getWithdrawal(item.txHash)) as any;
+          const blockNumber = result?.l2_committed_info.block_number;
+          if (blockNumber) {
+            data = {
+              ...data,
+              status: result?.l1_committed_info?.transaction_hash ? "pending" : "l2Pending",
+              remainingBlockNumber: blockNumber ? Math.max(0, blockNumber - lastFinalizedBlockNumber) : undefined,
+              withdrawalBlockNumber: blockNumber,
+              layer1TxHash: result?.l1_committed_info?.transaction_hash,
+            };
+          }
+          resolve(data);
+        } catch (_) {
+          resolve(data);
+        }
+      }),
+    );
+  }
+  return await Promise.all(promises);
 }

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { LightGodwokenV1 } from "light-godwoken";
+import { LightGodwokenV1, ProxyERC20 } from "light-godwoken";
 import { AxiosError } from "axios";
 import styled from "styled-components";
 import { LinkList, Tab } from "../../style/common";
@@ -31,6 +31,7 @@ interface WithdrawalHistoryType {
   txHash: string;
   amount: string;
   capacity: string;
+  erc20?: ProxyERC20;
 }
 
 interface Props {
@@ -247,6 +248,7 @@ async function getPendingHistoriesByRPC(lightGodwoken: LightGodwokenV1, txHistor
           capacity: item.capacity,
           status: "l2Pending",
           txHash: item.txHash,
+          erc20: item.token as ProxyERC20,
         };
         try {
           const result = (await lightGodwoken.getWithdrawal(item.txHash)) as any;
@@ -258,6 +260,7 @@ async function getPendingHistoriesByRPC(lightGodwoken: LightGodwokenV1, txHistor
               remainingBlockNumber: blockNumber ? Math.max(0, blockNumber - lastFinalizedBlockNumber) : undefined,
               withdrawalBlockNumber: blockNumber,
               layer1TxHash: result?.l1_committed_info?.transaction_hash,
+              sudt_script_hash: result?.withdrawal?.request?.raw?.sudt_script_hash,
             };
           }
           resolve(data);

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -196,16 +196,16 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory, rem
       {isPending && (
         <div className="list pending-list">
           {pendingList.length === 0 && <Empty>No pending withdrawals</Empty>}
-          {pendingList.map((withdraw, index) => (
-            <WithdrawalRequestCard {...withdraw} key={index}></WithdrawalRequestCard>
+          {pendingList.map((withdraw) => (
+            <WithdrawalRequestCard {...withdraw} key={withdraw.txHash}></WithdrawalRequestCard>
           ))}
         </div>
       )}
       {isCompleted && (
         <div ref={listRef} className="list pending-list">
           {completedList.length === 0 && <Empty>No completed withdrawals</Empty>}
-          {completedList.map((withdraw, index) => (
-            <WithdrawalRequestCard {...withdraw} key={index}></WithdrawalRequestCard>
+          {completedList.map((withdraw) => (
+            <WithdrawalRequestCard {...withdraw} key={withdraw.layer1TxHash}></WithdrawalRequestCard>
           ))}
         </div>
       )}

--- a/apps/godwoken-bridge/src/components/Withdrawal/RequestWithdrawalV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/RequestWithdrawalV1.tsx
@@ -75,7 +75,7 @@ const RequestWithdrawalV1: React.FC<{ addTxToHistory: (txHistory: BaseL1TxHistor
     }
 
     eventEmitter.on("sent", (txHash) => {
-      addTxToHistory({ txHash, amount, capacity, type: "withdrawal" });
+      addTxToHistory({ txHash, amount, capacity, type: "withdrawal", token: selectedSudt });
       notification.success({
         message: `Withdrawal Tx(${txHash}) has been sent`,
       });

--- a/apps/godwoken-bridge/src/components/Withdrawal/RequestWithdrawalV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/RequestWithdrawalV1.tsx
@@ -75,9 +75,9 @@ const RequestWithdrawalV1: React.FC<{ addTxToHistory: (txHistory: BaseL1TxHistor
     }
 
     eventEmitter.on("sent", (txHash) => {
+      addTxToHistory({ txHash, amount, capacity, type: "withdrawal" });
       notification.success({
-        message: `Withdrawal Tx(${txHash}) has been sent,it will take less than 5 minutes before the tx can be tracked and appear in the pending list, please wait...`,
-        duration: 0,
+        message: `Withdrawal Tx(${txHash}) has been sent`,
       });
       setCKBInput("");
       setSudtValue("");

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -145,7 +145,7 @@ const WithdrawalRequestCard = ({
   }, [capacity]);
 
   const handleToggleShowMore = useCallback(() => {
-    if (isMature) return;
+    if (isMature || status !== "pending") return;
     setShouldShowMore((value) => !value);
   }, [isMature]);
 
@@ -188,7 +188,7 @@ const WithdrawalRequestCard = ({
               <CheckCircleOutlined style={{ color: "#00CC9B", height: "21px", lineHeight: "21px" }} />
             </Tooltip>
           )}
-          {status === "fail" && (
+          {status === "failed" && (
             <Tooltip title={status}>
               <CloseCircleOutlined style={{ color: "#D03A3A", height: "21px", lineHeight: "21px" }} />
             </Tooltip>

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -19,9 +19,11 @@ const StyleWrapper = styled.div`
   background: #f3f3f3;
   padding: 16px;
   border-radius: 12px;
+
   & + & {
     margin-top: 16px;
   }
+
   .main-row {
     display: flex;
     flex-direction: row;
@@ -30,28 +32,34 @@ const StyleWrapper = styled.div`
     line-height: 1.5;
     font-size: 14px;
   }
+
   .amount {
     display: flex;
     flex-direction: column;
     justify-content: center;
+
     img,
     svg {
       width: 22px;
       height: 22px;
       margin-right: 5px;
     }
+
     .ckb-icon {
       display: flex;
       align-items: center;
     }
+
     .ckb-amount {
       display: flex;
       align-items: center;
     }
+
     .sudt-amount + .ckb-amount {
       margin-top: 6px;
     }
   }
+
   .right-side {
     height: 40px;
     display: flex;
@@ -60,17 +68,21 @@ const StyleWrapper = styled.div`
     justify-content: center;
     cursor: pointer;
   }
+
   .time {
     font-size: 12px;
     color: ${COLOR.secondary};
+
     svg {
       margin-left: 5px;
     }
   }
+
   .list-detail {
     margin-top: 10px;
     padding-top: 10px;
     border-top: 1px dashed rgba(0, 0, 0, 0.2);
+
     a {
       color: ${COLOR.brand};
       text-decoration: none;
@@ -82,6 +94,7 @@ export const FixedHeightRow = styled.div`
   height: 24px;
   display: flex;
   justify-content: space-between;
+
   .ant-typography {
     color: black;
     font-size: 16px;
@@ -99,6 +112,7 @@ export interface IWithdrawalRequestCardProps {
   erc20?: ProxyERC20;
   now?: number;
 }
+
 const WithdrawalRequestCard = ({
   remainingBlockNumber = 0,
   layer1TxHash,
@@ -147,7 +161,13 @@ const WithdrawalRequestCard = ({
   const handleToggleShowMore = useCallback(() => {
     if (isMature || status !== "pending") return;
     setShouldShowMore((value) => !value);
-  }, [isMature]);
+  }, [isMature, status]);
+
+  useEffect(() => {
+    if ((status === "available" || (status === "pending" && isMature)) && shouldShowMore) {
+      setShouldShowMore(false);
+    }
+  }, [status, isMature]);
 
   return (
     <StyleWrapper onClick={handleToggleShowMore}>

--- a/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
+++ b/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
@@ -10,7 +10,7 @@ const WithdrawalV1: React.FC = () => {
   const lightGodwoken = useLightGodwoken();
   const godwokenVersion = useGodwokenVersion();
   const l1Address = lightGodwoken?.provider.getL1Address();
-  const { txHistory, addTxToHistory, updateTxWithStatus } = useL1TxHistory(
+  const { txHistory, addTxToHistory, removeTxWithTxHashes } = useL1TxHistory(
     `${godwokenVersion}/${l1Address}/withdrawal`,
   );
 
@@ -31,7 +31,7 @@ const WithdrawalV1: React.FC = () => {
       </Card>
       {lightGodwoken && (
         <Card className="content">
-          <WithdrawalList txHistory={txHistory} updateTxWithStatus={updateTxWithStatus} />
+          <WithdrawalList txHistory={txHistory} removeTxWithTxHashes={removeTxWithTxHashes} />
         </Card>
       )}
     </PageContent>


### PR DESCRIPTION
### Discribe
1. After successfully initiating a withdrawal, the record will be displayed in the pending list immediately.
2. No longer use the `block_number` of  `withdrawal_histories` to calculate the estimated remaining time
3. This change is only valid for `Godwoken V1`

### Related problem
- fix #171  