### PR TITLE
Fix the status of a long time l2Pending withdrawal

### DIFF
--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -270,7 +270,7 @@ async function getPendingHistoriesByRPC(
           } else {
             // If a withdrawal stays in l2Pending too long, then it may have failed for some reason,
             // such as `over-withdraw`.
-            const elapsedMins = (Date.now() - new Date(withdrawalTx.date)) / 1000 / 60;
+            const elapsedMins = (Date.now() - new Date(withdrawalTx.date).getTime()) / 1000 / 60;
             if (elapsedMins > 3) withHis.status = "failed";
           }
           resolve(withHis);

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -210,7 +210,7 @@ const WithdrawalRequestCard = ({
             </Tooltip>
           )}
           {status === "failed" && (
-            <Tooltip title={status}>
+            <Tooltip title={"Failed withdrawal requests are not stored on-chain, and will be cleared after 3 days."}>
               <CloseCircleOutlined style={{ color: "#D03A3A", height: "21px", lineHeight: "21px" }} />
             </Tooltip>
           )}

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -110,7 +110,6 @@ export interface IWithdrawalRequestCardProps {
   amount: HexNumber;
   status: string;
   erc20?: ProxyERC20;
-  now?: number; // TODO: `now` is not used, remove it?
 }
 
 const WithdrawalRequestCard = ({

--- a/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -110,7 +110,7 @@ export interface IWithdrawalRequestCardProps {
   amount: HexNumber;
   status: string;
   erc20?: ProxyERC20;
-  now?: number;
+  now?: number; // TODO: `now` is not used, remove it?
 }
 
 const WithdrawalRequestCard = ({

--- a/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
+++ b/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
@@ -10,7 +10,7 @@ const WithdrawalV1: React.FC = () => {
   const lightGodwoken = useLightGodwoken();
   const godwokenVersion = useGodwokenVersion();
   const l1Address = lightGodwoken?.provider.getL1Address();
-  const { txHistory, addTxToHistory, removeTxWithTxHashes } = useL1TxHistory(
+  const { txHistory, addTxToHistory, removeTxWithTxHashes, updateTxWithStatus } = useL1TxHistory(
     `${godwokenVersion}/${l1Address}/withdrawal`,
   );
 
@@ -31,7 +31,11 @@ const WithdrawalV1: React.FC = () => {
       </Card>
       {lightGodwoken && (
         <Card className="content">
-          <WithdrawalList txHistory={txHistory} removeTxWithTxHashes={removeTxWithTxHashes} />
+          <WithdrawalList
+            txHistory={txHistory}
+            updateTxWithStatus={updateTxWithStatus}
+            removeTxWithTxHashes={removeTxWithTxHashes}
+          />
         </Card>
       )}
     </PageContent>

--- a/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
+++ b/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
@@ -10,7 +10,7 @@ const WithdrawalV1: React.FC = () => {
   const lightGodwoken = useLightGodwoken();
   const godwokenVersion = useGodwokenVersion();
   const l1Address = lightGodwoken?.provider.getL1Address();
-  const { txHistory, addTxToHistory, removeTxWithTxHashes, updateTxWithStatus } = useL1TxHistory(
+  const { txHistory, addTxToHistory, removeTxWithTxHashes } = useL1TxHistory(
     `${godwokenVersion}/${l1Address}/withdrawal`,
   );
 
@@ -31,11 +31,7 @@ const WithdrawalV1: React.FC = () => {
       </Card>
       {lightGodwoken && (
         <Card className="content">
-          <WithdrawalList
-            txHistory={txHistory}
-            updateTxWithStatus={updateTxWithStatus}
-            removeTxWithTxHashes={removeTxWithTxHashes}
-          />
+          <WithdrawalList txHistory={txHistory} removeTxWithTxHashes={removeTxWithTxHashes} />
         </Card>
       )}
     </PageContent>


### PR DESCRIPTION
Because the [WithdrawalWithStatus](https://github.com/godwokenrises/godwoken/blob/develop/docs/RPC.md#type-withdrawalwithstatus) from Godwoken RPC only has 2 status: pending | committed, it is not convenient to reveal the status of a failed withdrawal. So, I provide a simple solution:

    If a withdrawal stays in l2Pending too long,
    then it may have failed for some reason,
    such as `over-withdraw`.

## Preview
<img width="422" alt="image" src="https://user-images.githubusercontent.com/1297478/233265822-79e81fae-ba95-4ed4-9f5c-5dc0c8508191.png">

Since the data structures of `Pending` and `Completed` withdrawal lists are significantly different, I suggest just putting the failed record stay in the `Pending` list, and removing it after 3 days.

<img width="503" alt="image" src="https://user-images.githubusercontent.com/1297478/233402828-809f85c3-a67e-4bb3-8a77-db8197e13428.png">
