### PR TITLE
Modify the failed record retention time for the Pendinglist removal

### DIFF
--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -122,8 +122,8 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory, rem
     // remove outdated failed tx, failed records will be cleared after 3 days.
     for (const lth of localTxHistory) {
       if (lth.status !== "failed") continue;
-      const elapseddays = (Date.now() - new Date(lth.date).getTime()) / 1000 / 60 / 60 / 24;
-      if (elapseddays > 3) removeHashes.push(lth.txHash);
+      const elapsedMinss = (Date.now() - new Date(lth.date).getTime()) / 1000 / 60;
+      if (elapsedMinss > 3) removeHashes.push(lth.txHash);
     }
 
     removeTxWithTxHashes(removeHashes);

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -119,12 +119,22 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory, rem
       }
     }
 
-    // remove outdated failed tx, failed records will be cleared after 3 days.
-    for (const lth of localTxHistory) {
+    for (const lth of pendingList) {
       if (lth.status !== "failed") continue;
-      const elapsedMinss = (Date.now() - new Date(lth.date).getTime()) / 1000 / 60;
-      if (elapsedMinss > 30) removeHashes.push(lth.txHash);
+
+      const target = localTxHistory.find((row) => row.txHash === lth.txHash);
+      if (!target) continue;
+
+      const elapseddays = (Date.now() - new Date(target.date).getTime()) / 1000 / 60;
+      if (elapseddays > 10) removeHashes.push(lth.txHash);
     }
+
+    // remove outdated failed tx, failed records will be cleared after 3 days.
+    // for (const lth of localTxHistory) {
+    //   if (lth.status !== "failed") continue;
+    //   const elapsedMinss = (Date.now() - new Date(lth.date).getTime()) / 1000 / 60;
+    //   if (elapsedMinss > 30) removeHashes.push(lth.txHash);
+    // }
 
     removeTxWithTxHashes(removeHashes);
   }, [completedList, pendingList, localTxHistory, removeTxWithTxHashes]);

--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -123,7 +123,7 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory, rem
     for (const lth of localTxHistory) {
       if (lth.status !== "failed") continue;
       const elapsedMinss = (Date.now() - new Date(lth.date).getTime()) / 1000 / 60;
-      if (elapsedMinss > 3) removeHashes.push(lth.txHash);
+      if (elapsedMinss > 30) removeHashes.push(lth.txHash);
     }
 
     removeTxWithTxHashes(removeHashes);


### PR DESCRIPTION
The original expiration time was too long for testing, so it was changed to 10 minutes