### PR TITLE
Fix: remove outdated failed withdrawals

### DIFF
--- a/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
+++ b/apps/godwoken-bridge/src/components/Withdrawal/ListV1.tsx
@@ -120,10 +120,14 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory, rem
     }
 
     // remove outdated failed tx, failed records will be cleared after 3 days.
-    for (const lth of localTxHistory) {
+    for (const lth of pendingList) {
       if (lth.status !== "failed") continue;
-      const elapseddays = (Date.now() - new Date(lth.date).getTime()) / 1000 / 60 / 60 / 24;
-      if (elapseddays > 3) removeHashes.push(lth.txHash);
+
+      const targetLocalTx = localTxHistory.find((row) => row.txHash === lth.txHash);
+      if (!targetLocalTx) continue;
+
+      const elapsedDays = (Date.now() - new Date(targetLocalTx.date).getTime()) / 1000 / 60 / 60 / 24;
+      if (elapsedDays > 3) removeHashes.push(lth.txHash);
     }
 
     removeTxWithTxHashes(removeHashes);


### PR DESCRIPTION
## Issue
Previously in #300, we wanted to find outdated failed withdrawals in the `localTxHistory` variable and remove them. 
However, in our tests, @Dawn-githup and I discovered that the `failed` status is not updated in the `localTxHistory` variable.

SImply put, here's the `localTxHistory` in withdrawal v1 list:
- When new withdrawals was created, add new item to the `localTxHistory` and save to `localStorage`
- When rendering local pending withdrawals, load `localTxHistory` from `localStorage`
- When a item in `localTxHistory` is completed (comparing with a list from gwscan api), remove it from the `localTxHistory`

You can see there's no status check or update during the variable's lifecycle. Further more, items of the `localTxHistory` in the specific withdrawal v1 list don't have the `status` property we need. Therefore, when we tried to check items' `status` field of the `localTxHistory` variable, it won't work because the property was contained.

## Fix

The fix here is to use the `pendingList` variable instead of `localTxHistory`, which is a resolved pending list based on local pending withdrawals, but the status field is handled so it's not `undefined`.

Another issue left tho, is that items of `pendingList` don't have a `date` field, so after we find a failed withdrawal from `pendingList`, in order to find out if the failed withdrawal is outdated, we need to search for its local pending history from the `localTxHistory`, which seems to be a performance bomb.