### PR TITLE
Remove `yarn install` in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ yarn run clean:packages
 
 
 ### Run development of Godwoken bridge
+```bash
 $ cd ./app/godwoken-bridge
-$ yarn install
 $ yarn start
-
+```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ $ yarn run clean:packages
 ```
 
 
+### Run development of Godwoken bridge
+$ cd ./app/godwoken-bridge
+$ yarn install
+$ yarn start
+

--- a/apps/godwoken-bridge/package.json
+++ b/apps/godwoken-bridge/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.3",
   "private": true,
   "scripts": {
-    "start": "REACT_APP_COMMIT_HASH=$(git rev-parse --short HEAD) vite",
+    "start": "REACT_APP_COMMIT_HASH=$(git rev-parse --short HEAD) vite --open",
     "build": "tsc && REACT_APP_COMMIT_HASH=$(git rev-parse --short HEAD) vite build",
     "clean": "rm -rf ./dist && rm tsconfig.tsbuildinfo",
     "format:check": "prettier --check '**/*.{js,jsx,ts,tsx}'",


### PR DESCRIPTION
- Remove `yarn install` in Readme file, developers do not need to install packages in `app/godwoken-bridge` 