### PR TITLE
Update block_interval_seconds of Godwoken mainnet_v1

### DIFF
--- a/packages/light-godwoken/src/config/predefined/mainnet.ts
+++ b/packages/light-godwoken/src/config/predefined/mainnet.ts
@@ -138,7 +138,9 @@ export const MainnetLayer2ConfigV1: LightGodwokenConfig = {
     SCANNER_API: "https://api.v1.gwscan.com/api/",
     CHAIN_NAME: "Godwoken Mainnet v1",
     FINALITY_BLOCKS: 16800,
-    BLOCK_PRODUCE_TIME: 36, // L2 average block produce time from GwScan
+    // delay seconds between Godwoken blocks, defined by Godwoken mainnet_v1's fullnode
+    // see https://github.com/godwokenrises/godwoken/blob/v1.14.0/crates/config/src/config.rs#L184-L185
+    BLOCK_PRODUCE_TIME: 36,
     MIN_CANCEL_DEPOSIT_TIME: 604800,
 
     // https://github.com/mds1/multicall/commit/a6ed03f4bb232a573e9f6d4bdeca21a4edd3c1f7

--- a/packages/light-godwoken/src/config/predefined/mainnet.ts
+++ b/packages/light-godwoken/src/config/predefined/mainnet.ts
@@ -138,7 +138,7 @@ export const MainnetLayer2ConfigV1: LightGodwokenConfig = {
     SCANNER_API: "https://api.v1.gwscan.com/api/",
     CHAIN_NAME: "Godwoken Mainnet v1",
     FINALITY_BLOCKS: 16800,
-    BLOCK_PRODUCE_TIME: 45, // L2 average block produce time from GwScan
+    BLOCK_PRODUCE_TIME: 36, // L2 average block produce time from GwScan
     MIN_CANCEL_DEPOSIT_TIME: 604800,
 
     // https://github.com/mds1/multicall/commit/a6ed03f4bb232a573e9f6d4bdeca21a4edd3c1f7


### PR DESCRIPTION
Update the configuration of BLOCK_PRODUCE_TIME of Godwoken mainnet_v1 due to:
- https://github.com/godwokenrises/godwoken/discussions/1087

## Tests
1. 
![image](https://github.com/godwokenrises/light-godwoken/assets/1297478/f274d9df-f43e-42ee-ba71-1d7401e2613f)

2. 
![image](https://github.com/godwokenrises/light-godwoken/assets/1297478/cf612d4c-de03-4bc0-a705-a2a3cc4911d6)
