### PR TITLE
feat: switchable phase-out alert

### DIFF
--- a/apps/godwoken-bridge/src/App.tsx
+++ b/apps/godwoken-bridge/src/App.tsx
@@ -6,6 +6,7 @@ import GodwokenBridge from "./views/GodwokenBridge";
 import Deposit from "./views/Deposit";
 import Withdrawal from "./views/withdrawal/Withdrawal";
 import L1Transfer from "./views/L1Transfer";
+import { ShowOnPhaseOut } from "./components/PhaseOut/ShowOnPhaseOut";
 
 function App() {
   const queryClient = new QueryClient();
@@ -16,10 +17,13 @@ function App() {
           <Routes>
             <Route path="/" element={<Navigate to="v1" />} />
             <Route path=":version/*" element={<GodwokenBridge />}>
-              <Route index element={<Navigate to="deposit" />} />
+              <Route
+                index
+                element={<ShowOnPhaseOut is={<Navigate to="withdrawal" />} not={<Navigate to="deposit" />} />}
+              />
               <Route path="deposit">
                 <Route index element={<Navigate to="pending" />} />
-                <Route path=":status" element={<Deposit />} />
+                <Route path=":status" element={<ShowOnPhaseOut is={<Navigate to="/" />} not={<Deposit />} />} />
               </Route>
               <Route path="withdrawal">
                 <Route index element={<Navigate to="pending" />} />

--- a/apps/godwoken-bridge/src/components/Layout/PageHeader.tsx
+++ b/apps/godwoken-bridge/src/components/Layout/PageHeader.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@ricons/utils";
 import { OpenInNewRound } from "@ricons/material";
 import { PopoverMenu } from "../PopoverMenu";
 import { VersionSelect } from "../VersionSelect";
+import { ShowOnPhaseOut } from "../PhaseOut/ShowOnPhaseOut";
 import { matchPath, useLocation, useParams } from "react-router-dom";
 
 import { ReactComponent as Logo } from "../../assets/logo.svg";
@@ -178,9 +179,13 @@ export default function PageHeader() {
           <Logo height={27} />
         </div>
         <div className="link-list">
-          <HeaderTab to={`/${params.version}/deposit`} pattern="/:version/deposit/*">
-            Deposit
-          </HeaderTab>
+          <ShowOnPhaseOut
+            not={
+              <HeaderTab to={`/${params.version}/deposit`} pattern="/:version/deposit/*">
+                Deposit
+              </HeaderTab>
+            }
+          />
           <HeaderTab to={`/${params.version}/withdrawal`} pattern="/:version/withdrawal/*">
             Withdrawal
           </HeaderTab>

--- a/apps/godwoken-bridge/src/components/PhaseOut/PhaseOutCard.tsx
+++ b/apps/godwoken-bridge/src/components/PhaseOut/PhaseOutCard.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import styled from "styled-components";
+import { Icon } from "@ricons/utils";
+import { OpenInNewRound } from "@ricons/material";
+import { ShowOnPhaseOut } from "./ShowOnPhaseOut";
+import { Card } from "../../style/common";
+
+const Wrapper = styled.div`
+  padding: 0 16px;
+
+  .fade-out-card {
+    margin-bottom: -36px;
+    padding: 20px 20px 60px 20px;
+    border-radius: 24px 24px 0 0;
+    background-color: #1d785e;
+  }
+
+  .title {
+    text-transform: uppercase;
+    margin-bottom: 12px;
+    font-weight: 800;
+    font-size: 18px;
+    color: #ffffff;
+  }
+
+  .description {
+    margin-bottom: 12px;
+    font-weight: 600;
+    font-size: 14px;
+    color: #eaeaea;
+
+    p {
+      margin-bottom: 4px;
+
+      a {
+        text-decoration: underline;
+        text-decoration-color: #e8e8e8;
+      }
+    }
+
+    b {
+      color: #ffffff;
+    }
+  }
+
+  .link {
+    padding: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: rgba(0, 0, 0, 0.4);
+    transition: all 0.1s;
+    border-radius: 16px;
+    font-size: 14px;
+
+    &:hover {
+      text-decoration: underline;
+      text-decoration-color: #e8e8e8;
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+
+    .link-title {
+      color: #ffffff;
+      font-weight: 700;
+      font-size: 13px;
+    }
+
+    .link-href {
+      color: #dfdddd;
+      font-size: 12px;
+    }
+
+    .icon {
+      display: flex;
+      align-items: center;
+      margin-left: 4px;
+      font-size: 16px;
+      color: #dfdddd;
+    }
+  }
+`;
+
+export function PhaseOutCard() {
+  return (
+    <ShowOnPhaseOut
+      is={
+        <Wrapper>
+          <Card className="fade-out-card">
+            <div className="title">Godwoken Phase-out</div>
+            <div className="description">
+              <p>
+                To align with the evolving landscape of the CKB ecosystem, we are sunsetting{" "}
+                <a href="https://forcebridge.com/" target="_blank">
+                  <b>Force Bridge</b>
+                </a>{" "}
+                and{" "}
+                <a href="https://www.godwoken.com/" target="_blank">
+                  <b>Godwoken</b>
+                </a>
+                .
+              </p>
+              <p>
+                During this period, all deposit pipelines are paused on Godwoken Bridge. Please withdraw all assets to
+                CKB before <b>October 31 2025</b>.
+              </p>
+            </div>
+            <a href="https://sunset.forcebridge.com/" target="_blank">
+              <div className="link">
+                <div>
+                  <div className="link-title">End of an Era: Force Bridge Sunset</div>
+                  <div className="link-href">https://sunset.forcebridge.com</div>
+                </div>
+                <div className="icon">
+                  <Icon>
+                    <OpenInNewRound />
+                  </Icon>
+                </div>
+              </div>
+            </a>
+          </Card>
+        </Wrapper>
+      }
+    />
+  );
+}

--- a/apps/godwoken-bridge/src/components/PhaseOut/ShowOnPhaseOut.tsx
+++ b/apps/godwoken-bridge/src/components/PhaseOut/ShowOnPhaseOut.tsx
@@ -1,0 +1,13 @@
+import React, { ReactNode } from "react";
+
+export const ShowOnPhaseOut: React.FC<{
+  is?: ReactNode;
+  not?: ReactNode;
+}> = (props: { is?: ReactNode; not?: ReactNode }) => {
+  if (!props.is && !props.not) {
+    throw new Error('Either "is" or "not" prop must be provided');
+  }
+  return process.env.REACT_APP_PHASE_OUT === "true"
+    ? ((props.is ?? null) as JSX.Element)
+    : ((props.not ?? null) as JSX.Element);
+};

--- a/apps/godwoken-bridge/src/views/Deposit.tsx
+++ b/apps/godwoken-bridge/src/views/Deposit.tsx
@@ -265,13 +265,7 @@ export default function Deposit() {
               To deposit, transfer CKB or supported sUDT tokens to your L1 Wallet Address first
             </Text>
           </CardHeader>
-          <WalletInfo
-            l1Address={l1Address}
-            ethAddress={ethAddress}
-            depositAddress={depositAddress}
-            l1Balance={CKBBalance}
-            l2Balance={l2CKBBalance}
-          ></WalletInfo>
+          <WalletInfo />
           <CKBInputPanel
             value={CKBInput}
             onUserInput={setCKBInput}

--- a/apps/godwoken-bridge/src/views/GodwokenBridge.tsx
+++ b/apps/godwoken-bridge/src/views/GodwokenBridge.tsx
@@ -7,6 +7,7 @@ import PageFooter from "../components/Layout/PageFooter";
 import { GodwokenVersion } from "light-godwoken";
 import { availableVersions } from "../utils/environment";
 import NetworkMismatchAlert from "../components/NetworkMismatchAlert";
+import { PhaseOutCard } from "../components/PhaseOut/PhaseOutCard";
 
 export default function GodwokenBridge() {
   const params = useParams();
@@ -19,6 +20,7 @@ export default function GodwokenBridge() {
     <Page>
       <NetworkMismatchAlert />
       <PageHeader />
+      <PhaseOutCard />
       <Outlet />
       <PageFooter />
     </Page>

--- a/apps/godwoken-bridge/src/views/L1Transfer.tsx
+++ b/apps/godwoken-bridge/src/views/L1Transfer.tsx
@@ -1,8 +1,10 @@
-import { useLightGodwoken } from "../hooks/useLightGodwoken";
+import React from "react";
 import { Card, CardHeader, PageContent, Text } from "../style/common";
+import { WalletInfo } from "../components/WalletInfo";
 import { WalletConnect } from "../components/WalletConnect";
-import RequestL1Transfer from "../components/L1Transfer/RequestL1Transfer";
 import L1TransferList from "../components/L1Transfer/L1TransferList";
+import RequestL1Transfer from "../components/L1Transfer/RequestL1Transfer";
+import { useLightGodwoken } from "../hooks/useLightGodwoken";
 
 export default function L1Transfer() {
   // light-godwoken client
@@ -18,6 +20,7 @@ export default function L1Transfer() {
               <span>L1 Transfer</span>
             </Text>
           </CardHeader>
+          <WalletInfo hideDepositAddress={true} hideEthAddress={true} hideL2Balance={true} />
           <RequestL1Transfer />
         </div>
       </Card>

--- a/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV0.tsx
+++ b/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV0.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { WalletInfo } from "../../components/WalletInfo";
 import { WalletConnect } from "../../components/WalletConnect";
 import { WithdrawalList } from "../../components/Withdrawal/ListV0";
 import RequestWithdrawalV0 from "../../components/Withdrawal/RequestWithdrawalV0";
@@ -17,6 +19,7 @@ const WithdrawalV0: React.FC = () => {
               <span>Withdrawal</span>
             </Text>
           </CardHeader>
+          <WalletInfo hideDepositAddress={true} />
           <div className="request-withdrawal">
             <RequestWithdrawalV0 />
           </div>

--- a/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
+++ b/apps/godwoken-bridge/src/views/withdrawal/WithdrawalV1.tsx
@@ -1,6 +1,8 @@
+import React from "react";
 import { WithdrawalList } from "../../components/Withdrawal/ListV1";
 import RequestWithdrawalV1 from "../../components/Withdrawal/RequestWithdrawalV1";
 import { Card, CardHeader, PageContent, Text } from "../../style/common";
+import { WalletInfo } from "../../components/WalletInfo";
 import { WalletConnect } from "../../components/WalletConnect";
 import { useLightGodwoken } from "../../hooks/useLightGodwoken";
 import { useGodwokenVersion } from "../../hooks/useGodwokenVersion";
@@ -24,6 +26,7 @@ const WithdrawalV1: React.FC = () => {
               <span>Withdrawal</span>
             </Text>
           </CardHeader>
+          <WalletInfo hideDepositAddress={true} />
           <div className="request-withdrawal">
             <RequestWithdrawalV1 addTxToHistory={addTxToHistory} />
           </div>


### PR DESCRIPTION
## Changes
- Add a `PhaseOutCard` alert on all pages that is only visible when `REACT_APP_PHASE_OUT == 'true'`
- Add logic to hide the `Deposit` tab and redirect the app to `/` when `REACT_APP_PHASE_OUT == 'true'`
- Add `hide*` props in `WalletInfo`, and remove address/balance related props, and then display the component in withdraw v0/v1 pages and in l1-transfer page

## Status

1. The `REACT_APP_PHASE_OUT` variable is set to `true`  in preview env, and is `false` in production
2. When we need to display the alert in production (testnet/mainnet), we'll have to update its config on Vercel